### PR TITLE
increase max image size

### DIFF
--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -153,7 +153,7 @@ export const useGeneratorStore = defineStore("generator", () => {
     const queue = ref<ICurrentGeneration[]>([]);
 
     const minDimensions = ref(64);
-    const maxDimensions = computed(() => useOptionsStore().allowLargerParams === "Enabled" ? 3072 : 1024);
+    const maxDimensions = computed(() => useOptionsStore().allowLargerParams === "Enabled" ? 3072 : 1536);
     const minImages = ref(1);
     const maxImages = ref(20);
     const minSteps = ref(1);


### PR DESCRIPTION
SDXL works best  with 1024x1024 images, _or_ resolutions with approximately the same number of pixels ( https://arxiv.org/pdf/2307.01952#appendix.I , https://comfyanonymous.github.io/ComfyUI_examples/sdxl/ ). It should be safe to increase this limit, since server memory and processing are proportional to the image area, and larger images will be scaled down by Koboldcpp's default 1024x1024 soft resolution limit.

The value 1536 is somewhat arbitrary, and may be a bit above common usage:
* 1536 allows native 1536x640 (12:5, or 2.4)
* 1408 allows native 1408x704 (2:1)
* 1344 allows native 1344x768 (7:4, or 1.75), just a little bit below widescreen aspect ratio (16:9, or 1.77). Non-upscaled 1344x768 images are very common, eg. on Civitai.