### PR TITLE
button in image modal always visible, close on delete

### DIFF
--- a/src/components/ImageDialog.vue
+++ b/src/components/ImageDialog.vue
@@ -109,7 +109,9 @@ function downloadAvi() {
             <span v-if="currentOutput.extra_avi"> - <a href="#" @click.prevent="downloadAvi" style="cursor: pointer; color: var(--el-color-primary);">[Download AVI]</a></span>
         </div>
         <template #footer>
-            <ImageActions :image-data="currentOutput" />
+            <ImageActions 
+                :image-data="currentOutput"
+                :on-delete="handleClose" />
         </template>
     </el-dialog>
 </template>

--- a/src/components/ImageDialog.vue
+++ b/src/components/ImageDialog.vue
@@ -136,7 +136,7 @@ function downloadAvi() {
 }
 
 .image-viewer > .el-dialog__header {
-    padding: 26px;
+    padding: 12px 26px;
 }
 
 .image-viewer > .el-dialog__body {

--- a/src/components/ImageDialog.vue
+++ b/src/components/ImageDialog.vue
@@ -108,9 +108,9 @@ function downloadAvi() {
             <span>Frames: {{currentOutput.frames || "1"}}</span>
             <span v-if="currentOutput.extra_avi"> - <a href="#" @click.prevent="downloadAvi" style="cursor: pointer; color: var(--el-color-primary);">[Download AVI]</a></span>
         </div>
-        <div>
+        <template #footer>
             <ImageActions :image-data="currentOutput" />
-        </div>
+        </template>
     </el-dialog>
 </template>
 
@@ -149,6 +149,14 @@ function downloadAvi() {
     overflow-y: scroll;
     padding-top: 0;
     height: 100%;
+}
+
+.image-viewer > .el-dialog__footer {
+    border-top: 1px solid var(--el-border-color);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    row-gap: 8px;
 }
 
 @media only screen and (max-width: 1280px) {


### PR DESCRIPTION
- close modal on delete
- image button action always visible without scrolling

<table>
<tr> 
 <td>Before
 <td>After
<tr>
 <td>
<img width="1032" height="677" alt="image" src="https://github.com/user-attachments/assets/1199a62c-3242-4da4-bfa9-1dd392701118" />
 <td>
<img width="1033" height="677" alt="image" src="https://github.com/user-attachments/assets/e64b46ae-3f4f-495b-811f-30eb72a1629f" />
<tr>
<td>
<img width="485" height="856" alt="image" src="https://github.com/user-attachments/assets/9d26e149-b34a-4291-9af2-0853ed15570f" />

<td>
<img width="485" height="855" alt="image" src="https://github.com/user-attachments/assets/cdaf9811-e906-4ed7-8ec2-e6d4ccadcfe2" />

</table>