### PR TITLE
Make images-top-bar more accessible

### DIFF
--- a/src/utils/useMobileScrollHide.ts
+++ b/src/utils/useMobileScrollHide.ts
@@ -1,0 +1,22 @@
+import { ref, computed, watch } from 'vue'
+import { useScroll, useWindowSize } from '@vueuse/core'
+
+export function useMobileScrollHide(threshold = 5) {
+  const { width } = useWindowSize()
+  const isMobile = computed(() => width.value <= 768)
+  const isVisible = ref(true)
+
+  const { y, directions } = useScroll(window)
+
+  watch(y, () => {
+    if (!isMobile.value) return
+
+    if (directions.bottom && y.value > threshold) {
+      isVisible.value = false
+    } else if (directions.top) {
+      isVisible.value = true
+    }
+  })
+
+  return { isVisible, isMobile }
+}

--- a/src/views/ImagesView.vue
+++ b/src/views/ImagesView.vue
@@ -24,9 +24,11 @@ import { onKeyStroke } from '@vueuse/core';
 import { downloadMultipleImages } from '@/utils/download';
 import { db } from '@/utils/db';
 import { useWindowSize } from '@vueuse/core'
+import { useMobileScrollHide } from '@/utils/useMobileScrollHide'
 import LayoutOutlined from '@/components/icons/LayoutOutlined.vue';
 
 const { width } = useWindowSize();
+const { isVisible: showTopBar, isMobile } = useMobileScrollHide();
 
 const store = useOutputStore();
 const optionStore = useOptionsStore();
@@ -102,7 +104,7 @@ const splitList = computed(() => {
 </script>
 
 <template>
-    <div class="images-top-bar">
+    <div class="images-top-bar" :class="{ 'mobile-hidden': isMobile && !showTopBar }">
         <div class="options">
             <el-popover
                 placement="bottom"
@@ -261,6 +263,18 @@ const splitList = computed(() => {
     align-items: center;
     justify-content: space-between;
     margin-bottom: 12px;
+    gap: 8px;
+    position: sticky;
+    top: 60px;
+    z-index: 99;
+    padding: 8px;
+    background-color: color-mix(in srgb, var(--el-bg-color-overlay) 60%, transparent);
+    border-bottom: 1px solid var(--el-border-color);
+    transition: transform 0.3s ease-in-out;
+}
+
+.images-top-bar.mobile-hidden {
+    transform: translateY(-100%);
 }
 
 .images-top-bar > * {
@@ -278,6 +292,7 @@ const splitList = computed(() => {
 
 @media only screen and (max-width: 768px) {
     .images-top-bar {
+        top: 0;
         flex-wrap: wrap;
     }
 


### PR DESCRIPTION
- make images-top-bar sticky on top while scrolling down to make it easy to interact without scrolling back up.
- on mobile ui make it auto hide on scroll down, but show again on scroll up
- add auto hide util for mobile ui

<img width="443" height="867" alt="image" src="https://github.com/user-attachments/assets/7385db2a-9bce-4d8a-946f-c7ea5871dfe1" />
<img width="443" height="867" alt="image" src="https://github.com/user-attachments/assets/7aa536f2-fc95-46cf-b9b7-b793ec44df91" />
<img width="444" height="933" alt="image" src="https://github.com/user-attachments/assets/bb6b008e-b986-42a9-933d-ae6efb5c3470" />
<img width="826" height="646" alt="image" src="https://github.com/user-attachments/assets/ede78559-1c98-4dc8-b375-ba0dc7a1b725" />
<img width="815" height="639" alt="image" src="https://github.com/user-attachments/assets/cb1eda9d-db40-4ac6-acf5-d5642a05cf59" />
