### PR TITLE
include the scheduler when showing image metadata

### DIFF
--- a/src/components/ImageDialog.vue
+++ b/src/components/ImageDialog.vue
@@ -100,6 +100,7 @@ function downloadAvi() {
             <div>Negative Prompt: {{currentOutput.prompt?.split("###")[1] || "None"}}</div>
             <span>Model: {{currentOutput.modelName || "Unknown"}} - </span>
             <span>Sampler: {{currentOutput.sampler_name || "Unknown"}} - </span>
+            <span>Scheduler: {{currentOutput.scheduler || "Unknown"}} - </span>
             <span>Seed: {{currentOutput.seed || "Unknown"}} - </span>
             <span>Steps: {{currentOutput.steps || "Unknown"}} - </span>
             <span>CFG Scale: {{currentOutput.cfg_scale || "Unknown"}} - </span>


### PR DESCRIPTION
This uses a straightforward extra field to show the chosen scheduler. It's different than the embedded metadata, which concatenates the scheduler to the sampler name; I could try that way if you wish (main advantage would be less screen area).
