### PR TITLE
Multi select improvements

### DIFF
--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -234,12 +234,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         // Cache parameters so the user can't mutate the output data while it's generating
         const paramsCached: any[] = [];
 
-        const getMultiSelect = <T>(item: IMultiSelectItem<T>, defaultValue: any): T[] => item.enabled ? item.selected : defaultValue;
-        const prompts      = promptMatrix();
-        const guidances    = getMultiSelect(multiSelect.value.guidance,    [params.value.cfg_scale]);
-        const steps        = getMultiSelect(multiSelect.value.steps,       [params.value.steps]);
-        const clipSkips    = getMultiSelect(multiSelect.value.clipSkip,    [params.value.clip_skip]);
-        const samplers     = getMultiSelect(multiSelect.value.sampler,     [params.value.sampler_name]);
+        const prompts = promptMatrix();
 
         let origseed: number = parseInt((params.value.seed).toString());
         if (isNaN(origseed) || origseed < 0) {
@@ -250,62 +245,85 @@ export const useGeneratorStore = defineStore("generator", () => {
             seeds.push(origseed + i);
         }
 
-        const models = [ await updateAvailableModels() ];
-        for (const currentGuidance of guidances) {
-            for (const currentSteps of steps) {
-                for (const currentClipSkip of clipSkips) {
-                for (const currentPrompt of prompts) {
-                    const p = currentPrompt.split(" ### ");
-                    for (const currentSampler of (
-                        samplers
-                    )) {
-                        for (const seed of seeds) {
-                            let newgen:any = {
-                                prompt: currentPrompt,
-                                params: {
-                                    ...params.value,
-                                    seed: seed,
-                                    sampler_name: currentSampler,
-                                    cfg_scale: currentGuidance,
-                                    steps: currentSteps,
-                                    clip_skip: currentClipSkip,
-                                    prompt: p[0],
-                                    negative_prompt: p[1] || "",
-                                    init_images: sourceImage ? [ sourceImage.split(",")[1] ] : [],
-                                    mask: maskImage,
-                                    inpainting_mask_invert: (maskImage?0:null),
-                                    inpainting_fill: (maskImage?1:null)
-                                },
-                                source_image: sourceImage?.split(",")[1],
-                                source_mask: maskImage,
-                                source_processing: sourceProcessing,
-                                models: models
-                            };
-                            //don't send any default or unwanted params
-                            if(newgen.params["sampler_name"]=="default")
-                            {
-                                delete newgen.params["sampler_name"];
-                            }
-                            if(newgen.params["scheduler"]=="default")
-                            {
-                                delete newgen.params["scheduler"];
-                            }
-                            if(newgen.params["frames"] && newgen.params["frames"]<=1)
-                            {
-                                delete newgen.params["frames"];
-                            }
-                            if(referenceBase64Images && referenceBase64Images.length>0)
-                            {
-                                newgen.params["extra_images"] = referenceBase64Images;
-                            }
-                            if(useOptionsStore().alsoRequestAvi === "Enabled" && newgen.params["frames"] && newgen.params["frames"]>1)
-                            {
-                                newgen.params["video_output_type"] = 2; //request avi to download as well
-                            }
-                            paramsCached.push(newgen);
-                        }
+        const getMultiSelect = <T>(item: IMultiSelectItem<T>, defaultValue: any): T[] => item.enabled ? item.selected : defaultValue;
+
+        let multiParams:any = {
+            seed:         seeds,
+            cfg_scale:    getMultiSelect(multiSelect.value.guidance,  [params.value.cfg_scale]),
+            steps:        getMultiSelect(multiSelect.value.steps,     [params.value.steps]),
+            clip_skip:    getMultiSelect(multiSelect.value.clipSkip,  [params.value.clip_skip]),
+            sampler_name: getMultiSelect(multiSelect.value.sampler,   [params.value.sampler_name]),
+        };
+
+        // exclude parameters handled by multiParams
+        const currentParams = { ...params.value };
+        for (const key of Object.keys(multiParams)) {
+            delete currentParams[key];
+        }
+
+        // given: {'a': [1, 2, 3], 'b':[4, 5], 'c':[]}
+        // returns: [{'a':1,'b':4},{'a':1,'b':5},{'a':2,'b':4},{'a':2,'b':5},{'a':3,'b':4},{'a':3,'b':5}]
+        const cartesianProduct = <T>(input: Record<string, any[]>): Record<string, any>[] => {
+            const entries = Object.entries(input).filter(([_, values]) => values.length > 0);
+            // will return the initial value [{}] if entries is empty
+            return entries.reduce<Record<string, T>[]>((acc, [key, values]) => {
+                const newAcc: Record<string, T>[] = [];
+                for (const currentObj of acc) {
+                    for (const value of values) {
+                        newAcc.push({ ...currentObj, [key]: value });
                     }
-                }}
+                }
+                return newAcc;
+            }, [{}]); 
+        }
+
+        const combinations = cartesianProduct(multiParams);
+        if (DEBUG_MODE) console.log("multi parameters:", multiParams)
+        if (DEBUG_MODE) console.log("combos:", combinations)
+
+        const models = [ await updateAvailableModels() ];
+        for (const currentPrompt of prompts) {
+            const p = currentPrompt.split(" ### ");
+            for (const combo of combinations) {
+                let newgen:any = {
+                    prompt: currentPrompt,
+                    params: {
+                        ...currentParams,
+                        ...combo,
+                        prompt: p[0],
+                        negative_prompt: p[1] || "",
+                        init_images: sourceImage ? [ sourceImage.split(",")[1] ] : [],
+                        mask: maskImage,
+                        inpainting_mask_invert: (maskImage?0:null),
+                        inpainting_fill: (maskImage?1:null)
+                    },
+                    source_image: sourceImage?.split(",")[1],
+                    source_mask: maskImage,
+                    source_processing: sourceProcessing,
+                    models: models
+                };
+                //don't send any default or unwanted params
+                if(newgen.params["sampler_name"]=="default")
+                {
+                    delete newgen.params["sampler_name"];
+                }
+                if(newgen.params["scheduler"]=="default")
+                {
+                    delete newgen.params["scheduler"];
+                }
+                if(newgen.params["frames"] && newgen.params["frames"]<=1)
+                {
+                    delete newgen.params["frames"];
+                }
+                if(referenceBase64Images && referenceBase64Images.length>0)
+                {
+                    newgen.params["extra_images"] = referenceBase64Images;
+                }
+                if(useOptionsStore().alsoRequestAvi === "Enabled" && newgen.params["frames"] && newgen.params["frames"]>1)
+                {
+                    newgen.params["video_output_type"] = 2; //request avi to download as well
+                }
+                paramsCached.push(newgen);
             }
         }
 

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -241,6 +241,15 @@ export const useGeneratorStore = defineStore("generator", () => {
         const clipSkips    = getMultiSelect(multiSelect.value.clipSkip,    [params.value.clip_skip]);
         const samplers     = getMultiSelect(multiSelect.value.sampler,     [params.value.sampler_name]);
 
+        let origseed: number = parseInt((params.value.seed).toString());
+        if (isNaN(origseed) || origseed < 0) {
+            origseed = getNewSeed();
+        }
+        const seeds: number[] = [];
+        for (let i = 0; i < params.value.n; i++) {
+            seeds.push(origseed + i);
+        }
+
         const models = [ await updateAvailableModels() ];
         for (const currentGuidance of guidances) {
             for (const currentSteps of steps) {
@@ -250,13 +259,7 @@ export const useGeneratorStore = defineStore("generator", () => {
                     for (const currentSampler of (
                         samplers
                     )) {
-                        let origseed:number = parseInt((params.value.seed).toString());
-                        if (isNaN(origseed) || origseed < 0)
-                        {
-                            origseed = getNewSeed();
-                        }
-                        for (let i = 0; i < params.value.n; i++) {
-                            const seed = (origseed + parseInt(i.toString()));
+                        for (const seed of seeds) {
                             let newgen:any = {
                                 prompt: currentPrompt,
                                 params: {

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -61,8 +61,8 @@ interface IPromptHistory {
 
 type IMultiSelectItem<T> = {
     name: string;
-    enabled: boolean;
-    noneMessage: string;
+    state: "Disabled" | "Enabled" | "Multiple";
+    allowedStates?: ('Disabled' | 'Enabled' | 'Multi-Select')[];
     selected: T[];
     mapToParam: (data: ImageData) => any;
 }
@@ -97,30 +97,37 @@ export const useGeneratorStore = defineStore("generator", () => {
     const multiSelect = ref<IMultiSelect>({
         sampler: {
             name: "Sampler",
-            enabled: false,
+            state: "Enabled",
+            allowedStates: ["Disabled", "Enabled", "Multiple"],
             selected: [params.value.sampler_name],
-            noneMessage: "Failed to generate: No sampler selected.",
             mapToParam: el => el.sampler_name,
+        },
+        scheduler: {
+            name: "Scheduler",
+            state: "Enabled",
+            allowedStates: ["Disabled", "Enabled"],
+            selected: [params.value.scheduler],
+            mapToParam: el => el.scheduler,
         },
         steps: {
             name: "Steps",
-            enabled: false,
+            state: "Enabled",
+            allowedStates: ["Disabled", "Enabled", "Multiple"],
             selected: [params.value.steps],
-            noneMessage: "Failed to generate: No steps selected.",
             mapToParam: el => el.steps,
         },
         guidance: {
             name: "CFG Scale",
-            enabled: false,
+            state: "Enabled",
+            allowedStates: ["Disabled", "Enabled", "Multiple"],
             selected: [params.value.cfg_scale],
-            noneMessage: "Failed to generate: No guidance selected.",
             mapToParam: el => el.cfg_scale,
         },
         clipSkip: {
             name: "Clip Skip",
-            enabled: false,
+            state: "Disabled",
+            allowedStates: ["Disabled", "Enabled", "Multiple"],
             selected: [params.value.clip_skip],
-            noneMessage: "Failed to generate: No CLIP Skip selected.",
             mapToParam: el => el.clip_skip,
         },
     });
@@ -183,7 +190,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         const multiCalc = (before: number, multiParam: IMultiSelectItem<any>, defaultMultiplier = 1) => before * (multiParam.enabled ? multiParam.selected.length : defaultMultiplier);
         const imageCount = params.value.n;
         const promptMatrixCount  = imageCount * promptMatrix().length;
-        const multiSamplerCount  = multiCalc(promptMatrixCount,    multiSelect.value.sampler);
+        const multiSamplerCount  = multiCalc(promptMatrixCount,  multiSelect.value.sampler);
         const multiStepsCount    = multiCalc(multiSamplerCount,  multiSelect.value.steps);
         const multiGuidanceCount = multiCalc(multiStepsCount,    multiSelect.value.guidance);
         const multiClipSkipCount = multiCalc(multiGuidanceCount, multiSelect.value.clipSkip);
@@ -219,9 +226,6 @@ export const useGeneratorStore = defineStore("generator", () => {
         if (!validGeneratorTypes.includes(type)) return [];
 
         if (prompt.value === "") return generationFailed("Failed to generate: No prompt submitted.");
-        for (const multi of Object.values(multiSelect.value)) {
-            if (multi.enabled && multi.selected.length === 0) return generationFailed(multi.noneMessage);
-        }
 
         const canvasStore = useCanvasStore();
         const uiStore = useUIStore();
@@ -245,14 +249,21 @@ export const useGeneratorStore = defineStore("generator", () => {
             seeds.push(origseed + i);
         }
 
-        const getMultiSelect = <T>(item: IMultiSelectItem<T>, defaultValue: any): T[] => item.enabled ? item.selected : defaultValue;
+        const getMultiSelect = <T>(item: IMultiSelectItem<T>): T[] => {
+            if (item.state === "Disabled" || (item.state === "Multiple" && item.selected.length == 0)) {
+                // disabled, or empty multiselect; the cartesian product will omit this field
+                return [];
+            }
+            return item.selected;
+        };
 
         let multiParams:any = {
             seed:         seeds,
-            cfg_scale:    getMultiSelect(multiSelect.value.guidance,  [params.value.cfg_scale]),
-            steps:        getMultiSelect(multiSelect.value.steps,     [params.value.steps]),
-            clip_skip:    getMultiSelect(multiSelect.value.clipSkip,  [params.value.clip_skip]),
-            sampler_name: getMultiSelect(multiSelect.value.sampler,   [params.value.sampler_name]),
+            cfg_scale:    getMultiSelect(multiSelect.value.guidance),
+            steps:        getMultiSelect(multiSelect.value.steps),
+            clip_skip:    getMultiSelect(multiSelect.value.clipSkip),
+            sampler_name: getMultiSelect(multiSelect.value.sampler),
+            scheduler:    getMultiSelect(multiSelect.value.scheduler),
         };
 
         // exclude parameters handled by multiParams

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -175,20 +175,20 @@ handleUrlParams();
                                 </el-tooltip>
                             </template>
                         </form-input>
-                        <form-select label="Sampler(s)"            prop="samplers"        v-model="store.multiSelect.sampler.selected"     :options="availableSamplers"  info="Multi-select enabled. Heun and DPM2 double generation time per step, but converge twice as fast." multiple v-if="store.multiSelect.sampler.enabled" />
-                        <form-select label="Sampler"               prop="sampler"         v-model="store.params.sampler_name"              :options="availableSamplers"  info="Heun and DPM2 double generation time per step, but converge twice as fast." v-else />
+                        <form-select label="Sampler(s)"            prop="samplers"        v-model="store.multiSelect.sampler.selected"     :options="availableSamplers"  info="Multi-select enabled. Heun and DPM2 double generation time per step, but converge twice as fast." multiple v-if="store.multiSelect.sampler.state === 'Multiple'" />
+                        <form-select label="Sampler"               prop="sampler"         v-model="store.params.sampler_name"              :options="availableSamplers"  info="Heun and DPM2 double generation time per step, but converge twice as fast." v-if="store.multiSelect.sampler.state === 'Enabled'" />
                         <form-slider label="Batch Size"            prop="batchSize"       v-model="store.params.n"                         :min="store.minImages"        :max="store.maxImages" />
-                        <form-slider label="Steps(s)"              prop="multiSteps"      v-model="store.multiSelect.steps.selected"       :min="store.minSteps"         :max="store.maxSteps"      info="Multi-select enabled. Keep step count between 30 to 50 for optimal generation times. Coherence typically peaks between 60 and 90 steps, with a trade-off in speed." multiple v-if="store.multiSelect.steps.enabled" />
-                        <form-slider label="Steps"                 prop="steps"           v-model="store.params.steps"                     :min="store.minSteps"         :max="store.maxSteps"      info="Keep step count between 30 to 50 for optimal generation times. Coherence typically peaks between 60 and 90 steps, with a trade-off in speed." v-else />
+                        <form-slider label="Steps(s)"              prop="multiSteps"      v-model="store.multiSelect.steps.selected"       :min="store.minSteps"         :max="store.maxSteps"      info="Multi-select enabled. Keep step count between 30 to 50 for optimal generation times. Coherence typically peaks between 60 and 90 steps, with a trade-off in speed." multiple v-if="store.multiSelect.steps.state === 'Multiple'" />
+                        <form-slider label="Steps"                 prop="steps"           v-model="store.params.steps"                     :min="store.minSteps"         :max="store.maxSteps"      info="Keep step count between 30 to 50 for optimal generation times. Coherence typically peaks between 60 and 90 steps, with a trade-off in speed." v-if="store.multiSelect.guidance.state === 'Enabled'" />
                         <form-slider label="Width"                 prop="width"           v-model="store.params.width"                     :min="store.minDimensions"    :max="store.maxDimensions" :step="64"   :change="onDimensionsChange" />
                         <form-slider label="Height"                prop="height"          v-model="store.params.height"                    :min="store.minDimensions"    :max="store.maxDimensions" :step="64"   :change="onDimensionsChange" />
-                        <form-slider label="Guidance(s)"           prop="cfgScales"       v-model="store.multiSelect.guidance.selected"    :min="store.minCfgScale"      :max="store.maxCfgScale"   info="Multi-select enabled. Higher values will make the AI respect your prompt more. Lower values allow the AI to be more creative." multiple v-if="store.multiSelect.guidance.enabled" />
-                        <form-slider label="Guidance"              prop="cfgScale"        v-model="store.params.cfg_scale"                 :min="store.minCfgScale"      :max="store.maxCfgScale"   :step="0.5"  info="Higher values will make the AI respect your prompt more. Lower values allow the AI to be more creative." v-else />
-                        <form-slider label="CLIP Skip(s)"          prop="clipSkips"       v-model="store.multiSelect.clipSkip.selected"    :min="store.minClipSkip"      :max="store.maxClipSkip"   info="Multi-select enabled. Last layers of CLIP to ignore. For most situations this can be left alone." multiple v-if="store.multiSelect.clipSkip.enabled" />
-                        <form-slider label="CLIP Skip"             prop="clipSkip"        v-model="store.params.clip_skip"                 :min="store.minClipSkip"      :max="store.maxClipSkip"   info="Last layers of CLIP to ignore. For most situations this can be left alone." v-else />
+                        <form-slider label="Guidance(s)"           prop="cfgScales"       v-model="store.multiSelect.guidance.selected"    :min="store.minCfgScale"      :max="store.maxCfgScale"   info="Multi-select enabled. Higher values will make the AI respect your prompt more. Lower values allow the AI to be more creative." multiple v-if="store.multiSelect.guidance.state === 'Multiple'" />
+                        <form-slider label="Guidance"              prop="cfgScale"        v-model="store.params.cfg_scale"                 :min="store.minCfgScale"      :max="store.maxCfgScale"   :step="0.5"  info="Higher values will make the AI respect your prompt more. Lower values allow the AI to be more creative." v-if="store.multiSelect.guidance.state === 'Enabled'" />
+                        <form-slider label="CLIP Skip(s)"          prop="clipSkips"       v-model="store.multiSelect.clipSkip.selected"    :min="store.minClipSkip"      :max="store.maxClipSkip"   info="Multi-select enabled. Last layers of CLIP to ignore. For most situations this can be left alone." multiple v-if="store.multiSelect.clipSkip.state === 'Multiple'" />
+                        <form-slider label="CLIP Skip"             prop="clipSkip"        v-model="store.params.clip_skip"                 :min="store.minClipSkip"      :max="store.maxClipSkip"   info="Last layers of CLIP to ignore. For most situations this can be left alone." v-if="store.multiSelect.clipSkip.state === 'Enabled'" />
                         <form-slider label="Init Strength"         prop="denoise"         v-model="store.params.denoising_strength"        :min="store.minDenoise"       :max="store.maxDenoise"    :step="0.01" info="The final image will diverge from the starting image at higher values. 0=unchanged, 1=fullychanged" v-if="store.sourceGeneratorTypes.includes(store.generatorType)" />
                         <form-slider label="Video Frames"          prop="frames"          v-model="store.params.frames"                    :min="store.minFrames"        :max="store.maxFrames"     info="Number of consecutive video frames to generate (Video models only). Max 80 frames, about 5 seconds of video."/>
-                        <form-select label="Scheduler"             prop="scheduler"       v-model="store.params.scheduler"            :options="availableSchedulers" info="Experimental! KoboldCpp only, allows you to use a different scheduler. Leave as default otherwise."/>
+                        <form-select label="Scheduler"             prop="scheduler"       v-model="store.params.scheduler"            :options="availableSchedulers" info="Experimental! KoboldCpp only, allows you to use a different scheduler. Leave as default otherwise." v-if="store.multiSelect.scheduler.state === 'Enabled'"/>
                         <div>
                         <span style="height: 100%;font-size: 14px;">Reference Image: <br>(Photomaker/Kontext) </span>
                         <input class="el-button"
@@ -207,21 +207,6 @@ handleUrlParams();
                             </el-col>
                         </el-row>
                         </div>
-                        <h3 style="margin: 16px 0 4px 0">Multi Select</h3>
-                        <el-row>
-                            <el-col :span="isMobile ? 24 : 12">
-                                <form-switch label="Multi Sampler"      prop="multiSamplerSwitch"  v-model="store.multiSelect.sampler.enabled" />
-                            </el-col>
-                            <el-col :span="isMobile ? 24 : 12">
-                                <form-switch label="Multi Guidance"     prop="multiGuidanceSwitch" v-model="store.multiSelect.guidance.enabled" />
-                            </el-col>
-                            <el-col :span="isMobile ? 24 : 12">
-                                <form-switch label="Multi CLIP Skip"    prop="multiClipSkipSwitch" v-model="store.multiSelect.clipSkip.enabled" />
-                            </el-col>
-                            <el-col :span="isMobile ? 24 : 12">
-                                <form-switch label="Multi Steps"        prop="multiStepsSwitch"    v-model="store.multiSelect.steps.enabled" />
-                            </el-col>
-                        </el-row>
                     </el-collapse-item>
                 </el-collapse>
             </div>

--- a/src/views/OptionsView.vue
+++ b/src/views/OptionsView.vue
@@ -24,9 +24,11 @@ import { ref } from 'vue';
 import { useOutputStore } from '@/stores/outputs';
 import { downloadMultipleImages } from '@/utils/download';
 import { db } from '@/utils/db';
+import { useGeneratorStore } from '@/stores/generator';
 
 const store = useOptionsStore();
 const outputsStore = useOutputStore();
+const generatorStore = useGeneratorStore();
 
 interface ColorModeOption {
     value: BasicColorSchema;
@@ -85,6 +87,10 @@ async function bulkDownload() {
                 <el-form-item label="Base URL">
                     <el-input class="apikey" prop="baseURL" v-model="store.baseURL" />
                 </el-form-item>
+                <h3>Parameter Controls</h3>
+                <div v-for="(item, key) in generatorStore.multiSelect" :key="key" >
+                    <form-radio :label="item.name" prop="pageless" v-model="item.state" :options="item.allowedStates" />
+                </div>
                 <form-radio  label="Allow Larger Params" prop="pageless" v-model="store.allowLargerParams" :options="['Enabled', 'Disabled']" />
                 <form-radio  label="Video Gen: Request AVI download" prop="pageless" v-model="store.alsoRequestAvi" :options="['Enabled', 'Disabled']" />
             </el-tab-pane>


### PR DESCRIPTION
I was thinking about how to include new parameter customization for newer models (like distilled guidance for Flux, flow shift, etc) without adding too much clutter to the interface, and came up with this idea:

- move the multi-select toggles to the Options tab
- change them into general enable / disable / multi-select configurations for each parameter control
- for disabled controls, simply omit the parameter from the request

So we also get a way to explicitly use the server's defaults for the parameters.

As additional tests, I made the clip_skip control disabled by default, since it's only useful for models that use CLIP (maybe only for SD1.5 and SDXL); also, added a non-multi-select toggle to disable the scheduler. Other candidates could be the video frame counter (that we can keep disabled most of the time) and batch size. We can keep things simple for casual users, and still allow power users to change less common parameters.

The main thing that is missing is persistence for the control toggles; I still need to figure out how that works.