### PR TITLE
map sampler name back to main name when reusing parameters

### DIFF
--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { defineStore } from "pinia";
 import { useOutputStore, type ImageData } from "./outputs";
 import { useUIStore } from "./ui";
@@ -521,15 +521,12 @@ export const useGeneratorStore = defineStore("generator", () => {
             negativePrompt.value = splitPrompt[1] || "";
         }
         if (data.sampler_name) {
-            const optionsStore = useOptionsStore();
-            const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
-            try {
-                const response = await fetch(`${baseUrl}/sdapi/v1/samplers`);
-                const samplers = await response.json();
-                const sampler = samplers.find((s: any) => s.name === data.sampler_name || (s.aliases && s.aliases.includes(data.sampler_name)));
-                params.value.sampler_name = sampler ? sampler.name : data.sampler_name;
-            } catch (e) {
-                params.value.sampler_name = data.sampler_name;
+            params.value.sampler_name = data.sampler_name;
+            // see if it is an alias instead of the main name
+            const samplers = await getAvailableSamplers();
+            const sampler = samplers.find((s: any) => (s.aliases && s.aliases.includes(data.sampler_name)));
+            if (sampler) {
+                params.value.sampler_name = sampler.name;
             }
         }
         if (data.steps)           params.value.steps = validateParam("steps", data.steps, maxSteps.value, defaults.steps as number);
@@ -643,6 +640,71 @@ export const useGeneratorStore = defineStore("generator", () => {
         if (!validateResponse(response, resJSON, 200, "Failed to get available models")) return;
         if (resJSON.length === 0) return "(No model loaded)";
         return resJSON[0].model_name;
+    }
+
+    // Cache variables
+    const cacheVersion = ref(0);
+    let samplersPromise: Promise<any[]> | null = null;
+    let schedulersPromise: Promise<any[]> | null = null;
+
+    function invalidateApiCaches() {
+        samplersPromise = null;
+        schedulersPromise = null;
+        cacheVersion.value++;
+    }
+
+    // Watch baseURL and clear cache if it changes
+    watch(
+        () => useOptionsStore().baseURL,
+        () => {
+            invalidateApiCaches();
+        }
+    );
+
+    async function getAvailableSamplers(): Promise<any[]> {
+        const optionsStore = useOptionsStore();
+        if (samplersPromise) {
+            return samplersPromise;
+        }
+        samplersPromise = (async () => {
+            try {
+                const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
+                const response = await fetch(`${baseUrl}/sdapi/v1/samplers`);
+                if (!response.ok) {
+                    samplersPromise = null;
+                    return [];
+                }
+                const resJSON: any[] = await response.json();
+                return Array.isArray(resJSON) ? resJSON : [];
+            } catch (e) {
+                samplersPromise = null;
+                return [];
+            }
+        })();
+        return samplersPromise;
+    }
+
+    async function getAvailableSchedulers(): Promise<any[]> {
+        const optionsStore = useOptionsStore();
+        if (schedulersPromise) {
+            return schedulersPromise;
+        }
+        schedulersPromise = (async () => {
+            try {
+                const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
+                const response = await fetch(`${baseUrl}/sdapi/v1/schedulers`);
+                if (!response.ok) {
+                    schedulersPromise = null;
+                    return [];
+                }
+                const resJSON: any[] = await response.json();
+                return Array.isArray(resJSON) ? resJSON : [];
+            } catch (e) {
+                schedulersPromise = null;
+                return [];
+            }
+        })();
+        return schedulersPromise;
     }
 
     function pushToNegativeLibrary(prompt: string) {
@@ -773,5 +835,11 @@ export const useGeneratorStore = defineStore("generator", () => {
         removeFromPromptHistory,
         setExtraImage,
         clearExtraImage,
+        samplersPromise,
+        getAvailableSamplers,
+        schedulersPromise,
+        getAvailableSchedulers,
+        cacheVersion,
+        invalidateApiCaches,
     };
 });

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -644,12 +644,10 @@ export const useGeneratorStore = defineStore("generator", () => {
 
     // Cache variables
     const cacheVersion = ref(0);
-    let samplersPromise: Promise<any[]> | null = null;
-    let schedulersPromise: Promise<any[]> | null = null;
+    const cacheMap = new Map<string, Promise<any>>();
 
     function invalidateApiCaches() {
-        samplersPromise = null;
-        schedulersPromise = null;
+        cacheMap.clear();
         cacheVersion.value++;
     }
 
@@ -661,50 +659,39 @@ export const useGeneratorStore = defineStore("generator", () => {
         }
     );
 
-    async function getAvailableSamplers(): Promise<any[]> {
+    // fetch endpoint information and keep a cache of the result
+    async function getCachedEndpoint<T>(endpoint: string): Promise<T | null> {
         const optionsStore = useOptionsStore();
-        if (samplersPromise) {
-            return samplersPromise;
+        const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
+        const fullUrl = (baseUrl.replace(/\/+$/, "") || ".") + "/" + endpoint.replace(/^\/+/, "");
+        if (cacheMap.has(fullUrl)) {
+            return cacheMap.get(fullUrl);
         }
-        samplersPromise = (async () => {
+        const fetchPromise = (async (): Promise<T | null> => {
             try {
-                const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
-                const response = await fetch(`${baseUrl}/sdapi/v1/samplers`);
-                if (!response.ok) {
-                    samplersPromise = null;
-                    return [];
+                const response = await fetch(fullUrl);
+                if (response.ok) {
+                    return (await response.json()) as T;
                 }
-                const resJSON: any[] = await response.json();
-                return Array.isArray(resJSON) ? resJSON : [];
-            } catch (e) {
-                samplersPromise = null;
-                return [];
+                console.error(`API Error: ${response.status} ${response.statusText} at ${fullUrl}`);
+            } catch (error) {
+                console.error(`Fetch error for ${fullUrl}:`, error);
             }
+            cacheMap.delete(fullUrl);
+            return null;
         })();
-        return samplersPromise;
+        cacheMap.set(fullUrl, fetchPromise);
+        return fetchPromise;
+    }
+
+    async function getAvailableSamplers(): Promise<any[]> {
+        const result = await getCachedEndpoint<any[]>("/sdapi/v1/samplers");
+        return Array.isArray(result) ? result : [];
     }
 
     async function getAvailableSchedulers(): Promise<any[]> {
-        const optionsStore = useOptionsStore();
-        if (schedulersPromise) {
-            return schedulersPromise;
-        }
-        schedulersPromise = (async () => {
-            try {
-                const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
-                const response = await fetch(`${baseUrl}/sdapi/v1/schedulers`);
-                if (!response.ok) {
-                    schedulersPromise = null;
-                    return [];
-                }
-                const resJSON: any[] = await response.json();
-                return Array.isArray(resJSON) ? resJSON : [];
-            } catch (e) {
-                schedulersPromise = null;
-                return [];
-            }
-        })();
-        return schedulersPromise;
+        const result = await getCachedEndpoint<any[]>("/sdapi/v1/schedulers");
+        return Array.isArray(result) ? result : [];
     }
 
     function pushToNegativeLibrary(prompt: string) {
@@ -835,11 +822,10 @@ export const useGeneratorStore = defineStore("generator", () => {
         removeFromPromptHistory,
         setExtraImage,
         clearExtraImage,
-        samplersPromise,
         getAvailableSamplers,
-        schedulersPromise,
         getAvailableSchedulers,
         cacheVersion,
         invalidateApiCaches,
+        getCachedEndpoint
     };
 });

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -502,7 +502,7 @@ export const useGeneratorStore = defineStore("generator", () => {
     /**
      * Prepare an image for going through text2img on the Horde
      * */
-    function generateText2Img(data: ImageData, correctDimensions = true) {
+    async function generateText2Img(data: ImageData, correctDimensions = true) {
         const defaults = getDefaultStore();
         generatorType.value = "Text2Img";
         multiSelect.value.guidance.state  = "Enabled";
@@ -520,7 +520,18 @@ export const useGeneratorStore = defineStore("generator", () => {
             prompt.value = splitPrompt[0];
             negativePrompt.value = splitPrompt[1] || "";
         }
-        if (data.sampler_name)    params.value.sampler_name = data.sampler_name;
+        if (data.sampler_name) {
+            const optionsStore = useOptionsStore();
+            const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
+            try {
+                const response = await fetch(`${baseUrl}/sdapi/v1/samplers`);
+                const samplers = await response.json();
+                const sampler = samplers.find((s: any) => s.name === data.sampler_name || (s.aliases && s.aliases.includes(data.sampler_name)));
+                params.value.sampler_name = sampler ? sampler.name : data.sampler_name;
+            } catch (e) {
+                params.value.sampler_name = data.sampler_name;
+            }
+        }
         if (data.steps)           params.value.steps = validateParam("steps", data.steps, maxSteps.value, defaults.steps as number);
         if (data.cfg_scale)       params.value.cfg_scale = data.cfg_scale;
         if (data.width)           params.value.width = validateParam("width", data.width, maxDimensions.value, defaults.width as number);

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -46,33 +46,21 @@ const uiStore = useUIStore();
 const canvasStore = useCanvasStore();
 const optionsStore = useOptionsStore();
 
-let samplerList = [] as string[];
-
 const availableSamplers = computedAsync(async () => {
-    if (samplerList.length === 0) {
-        try {
-            samplerList = (await (await fetch(`${optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL}/sdapi/v1/samplers`)).json()).map((el: any) => el.name);
-        } catch (e) {
-            samplerList = [];
-        }
-    }
+    const _ignore     = store.cacheVersion; // force update when cached value changes
+    const samplers    = await store.getAvailableSamplers();
+    const samplerList = samplers.map((el: any) => el.name);
     if (samplerList.length === 0) return [];
     return updateCurrentSampler(samplerList);
-})
-
-let schedulerList = [] as string[];
+}, [])
 
 const availableSchedulers = computedAsync(async () => {
-    if (schedulerList.length === 0) {
-        try {
-            schedulerList = (await (await fetch(`${optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL}/sdapi/v1/schedulers`)).json()).map((el: any) => el.name);
-        } catch (e) {
-            schedulerList = [];
-        }
-    }
+    const _ignore       = store.cacheVersion; // force update when cached value changes
+    const schedulers    = await store.getAvailableSchedulers();
+    const schedulerList = schedulers.map((el: any) => el.name);
     if (schedulerList.length === 0) return [];
     return updateCurrentScheduler(schedulerList);
-})
+}, [])
 
 const rules = reactive<FormRules>({
     prompt: [{


### PR DESCRIPTION
This is the counterpart to LostRuins/koboldcpp#2149 : if the server reports back a sampler with a different name (e.g. we ask for 'Euler A', image comes as 'euler_a'), try to find that name as a supported alias, and change it back to the main name.

I believe this is a better strategy because, by the time we try to reuse the parameters, we may be even talking to a different server. We could use the requested sampler instead, but it isn't available anymore for stored images.

We could try to refactor the sampler list fetching into a common function, but I think it's better to get it working first.

(by the way, this was made with the help of gemma-4-26B-A4B-it-UD-IQ4_NL running locally on Koboldcpp (79882d669), and pi-coding-agent. Works surprisingly well, although it often falls apart blabbering about `<channel|><|tool_call>` and stuff like that. Disabling `fastforward` _seems_ to have helped, but I need to test it better to make sure it isn't just a PEBKAC)