### PR TITLE
include the timestamp as a filename prefix for downloaded images

### DIFF
--- a/src/components/ImageActions.vue
+++ b/src/components/ImageActions.vue
@@ -50,6 +50,11 @@ const confirmDelete = () => {
         })
 }
 
+const getDownloadFilename = (imageData: ImageData) => {
+    const timestamp = imageData.job_timestamp ? `${imageData.job_timestamp}-` : '';
+    return `${timestamp}${imageData.seed}-${imageData.prompt}`;
+}
+
 const dismissImage = () => {
     useGeneratorStore().clearOutputs();
     useUIStore().showGeneratedImages = false;
@@ -106,7 +111,7 @@ async function copyLink(imageData: ImageData) {
 
 <template>
     <el-button class="compact-button" @click="confirmDelete" type="danger" size="small" :icon="Delete" plain>Delete</el-button>
-    <el-button class="compact-button" @click="downloadImage(imageData.image, `${imageData.seed}-${imageData.prompt}`)" type="success" size="small" :icon="Download" plain>Download</el-button>
+    <el-button class="compact-button" @click="downloadImage(imageData.image, getDownloadFilename(imageData))" type="success" size="small" :icon="Download" plain>Download</el-button>
     <el-button class="compact-button" v-if="!imageData.starred" @click="outputStore.toggleStarred(imageData.id)" type="warning" size="small" :icon="Star" plain>Star</el-button>
     <el-button class="compact-button" v-if="imageData.starred" @click="outputStore.toggleStarred(imageData.id)" type="warning" size="small" :icon="StarFilled" plain>Unstar</el-button>
     <el-button class="compact-button" @click="store.generateText2Img(imageData)" type="success" size="small" plain>Txt2img</el-button>

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -496,6 +496,10 @@ export const useGeneratorStore = defineStore("generator", () => {
                             }
                         });
 
+                        if (info['job_timestamp'] != null) {
+                            params.job_timestamp = info['job_timestamp'];
+                        }
+
                         // fields which need special mapping
                         if (info['extra_generation_params'] && info.extra_generation_params['Schedule type']) {
                             params.scheduler = info.extra_generation_params['Schedule type'];

--- a/src/stores/outputs.ts
+++ b/src/stores/outputs.ts
@@ -30,6 +30,7 @@ export interface ImageData {
     enable_hr?: 1 | 0;
     send_as_refimg?: 1 | 0;
     eta?: number;
+    job_timestamp?: string;
 }
 
 export const useOutputStore = defineStore("outputs", () => {


### PR DESCRIPTION
For LostRuins/koboldcpp#2104 . Very lightly tested.

The timestamp is server-generated, so existing images will keep the previous filenames. Shall we just use the current timestamp in this case?

Also, do we want some kind of control to enable it?