### PR TITLE
additional options for input image resizing

### DIFF
--- a/src/stores/canvas.ts
+++ b/src/stores/canvas.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import { useGeneratorStore } from "./generator";
+import { useOptionsStore } from "./options";
 import { fabric } from "fabric";
 
 export const useCanvasStore = defineStore("canvas", () => {
@@ -261,24 +262,121 @@ export const useCanvasStore = defineStore("canvas", () => {
         })
     }
 
+    /**
+     * Applies a transformation mode to a source canvas and returns a new canvas with the result.
+     */
+    function applyTransform(
+        src: HTMLCanvasElement,
+        targetWidth: number,
+        targetHeight: number,
+        bgColor: any,
+        mode: string
+    ): HTMLCanvasElement {
+        if (mode === "Original" || (src.width === targetWidth && src.height === targetHeight)) {
+            return src;
+        }
+
+        const dst = document.createElement('canvas');
+        dst.width = targetWidth;
+        dst.height = targetHeight;
+
+        const ctx = dst.getContext('2d')!;
+        ctx.fillStyle = bgColor;
+        ctx.fillRect(0, 0, dst.width, dst.height);
+
+        // Default source rectangle (entire source image)
+        let sx = 0, sy = 0, sw = src.width, sh = src.height;
+        // Default destination rectangle (entire target canvas)
+        let dx = 0, dy = 0, dw = dst.width, dh = dst.height;
+
+        switch (mode) {
+            case "Stretch":
+                // Defaults handle this: full source stretched to full target.
+                break;
+            case "ScaleAndCrop": {
+                // target filled completely, crop source to fit
+                // needs to crop the wider dimension
+                const wRatio = dst.width / src.width;
+                const hRatio = dst.height / src.height;
+                if (wRatio > hRatio) {
+                    sh = dst.height / wRatio;
+                    sy = (src.height - sh) / 2;
+                } else {
+                    sw = dst.width / hRatio;
+                    sx = (src.width - sw) / 2;
+                }
+                break;
+            }
+            case "ScaleAndPad": {
+                // full source, reduce target to keep aspect ratio
+                // needs to pad the narrower dimension
+                const wRatio = dst.width / src.width;
+                const hRatio = dst.height / src.height;
+                if (wRatio < hRatio) {
+                    dh = src.height * wRatio;
+                    dy = (dst.height - dh) / 2;
+                } else {
+                    dw = src.width * hRatio;
+                    dx = (dst.width - dw) / 2;
+                }
+                break;
+            }
+            case "NoScale":
+            default: {
+                // No scaling. Handle independent cropping or padding per axis.
+                if (src.width > dst.width) {
+                    // Crop Width: Source is wider than target
+                    sw = dst.width;
+                    sx = (src.width - dst.width) / 2;
+                } else {
+                    // Pad Width: Source is narrower than target
+                    dw = src.width;
+                    dx = (dst.width - src.width) / 2;
+                }
+
+                if (src.height > dst.height) {
+                    // Crop Height: Source is taller than target
+                    sh = dst.height;
+                    sy = (src.height - dst.height) / 2;
+                } else {
+                    // Pad Height: Source is shorter than target
+                    dh = src.height;
+                    dy = (dst.height - src.height) / 2;
+                }
+                break;
+            }
+        }
+
+        // Draw the calculated rectangle from source to destination
+        ctx.drawImage(src, sx, sy, sw, sh, dx, dy, dw, dh);
+
+        return dst;
+    }
+
     function saveImages() {
         const store = useGeneratorStore();
+        const optionsStore = useOptionsStore();
         if (!imageProps.value.imageLayer) return;
         if (!imageProps.value.drawLayer) return;
-        const cropX = imageProps.value.imageLayer.getCenter().left - (store.params.width as number / 2);
-        const cropWidth = store.params.width;
-        const cropY = imageProps.value.imageLayer.getCenter().top - (store.params.height as number / 2);
-        const cropHeight = store.params.height;
-        const dataUrlOptions = {
-            format: "jpeg",
-            quality: 1.0,
-            left: cropX,
-            top: cropY,
-            width: cropWidth,
-            height: cropHeight,
-        };
-        generatorImageProps.value.sourceImage = imageProps.value.imageLayer.toDataURL(dataUrlOptions);
-        generatorImageProps.value.maskImage = imageProps.value.redoHistory.length === 0 || drawing.value ? undefined : imageProps.value.drawLayer.toDataURL(dataUrlOptions).split(",")[1];
+
+        const targetWidth  = store.params.width as number;
+        const targetHeight = store.params.height as number;
+        const bgColor      = (imageProps.value.imageLayer.backgroundColor) || '#FFFFFF';
+        const resizeMode   = optionsStore.imageResizeMode;
+
+        const srcImageCanvas  = imageProps.value.imageLayer.toCanvasElement();
+        const destImageCanvas = applyTransform(srcImageCanvas, targetWidth, targetHeight, bgColor, resizeMode);
+
+        generatorImageProps.value.sourceImage = destImageCanvas.toDataURL('image/jpeg', 1.0);
+        generatorImageProps.value.maskImage   = undefined;
+
+        const includeMask = imageProps.value.redoHistory.length > 0 && !drawing.value;
+        if (includeMask) {
+            const srcMaskCanvas  = imageProps.value.drawLayer.toCanvasElement();
+            const destMaskCanvas = applyTransform(srcMaskCanvas, targetWidth, targetHeight, bgColor, resizeMode);
+
+            generatorImageProps.value.maskImage = destMaskCanvas.toDataURL('image/jpeg', 1.0).split(",")[1];
+        }
     }
 
     let timeout: undefined | NodeJS.Timeout;

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -17,6 +17,7 @@ export const useOptionsStore = defineStore("options", () => {
     const autoCarousel = useLocalStorage<IToggle>("autoCarousel", "Enabled");
     const useBeta = useLocalStorage<IToggle>("useBeta", "Disabled");
     const imageDownloadType = useLocalStorage<"WEBP" | "PNG" | "JPG" | "GIF" >("imageDownloadType", "PNG")
+    const imageResizeMode = useLocalStorage<"NoScale" | "Stretch" | "ScaleAndCrop" | "ScaleAndPad" | "Original">("imageResizeMode", "NoScale");
     const baseURL = useLocalStorage("baseURL", "");
 
     // A janky way to fix using color modes
@@ -35,6 +36,7 @@ export const useOptionsStore = defineStore("options", () => {
         autoCarousel,
         useBeta,
         imageDownloadType,
+        imageResizeMode,
         baseURL
     };
 });

--- a/src/views/OptionsView.vue
+++ b/src/views/OptionsView.vue
@@ -92,6 +92,19 @@ async function bulkDownload() {
                     <form-radio :label="item.name" prop="pageless" v-model="item.state" :options="item.allowedStates ?? []" />
                 </div>
                 <form-radio  label="Allow Larger Params" prop="pageless" v-model="store.allowLargerParams" :options="['Enabled', 'Disabled']" />
+                <form-select
+                    label="Image Resize Mode"
+                    prop="imageResizeMode"
+                    v-model="store.imageResizeMode"
+                    :options="[
+                        { label: 'No Scale', value: 'NoScale' },
+                        { label: 'Scale and Crop', value: 'ScaleAndCrop' },
+                        { label: 'Scale and Pad',  value: 'ScaleAndPad'  },
+                        { label: 'Stretch',  value: 'Stretch'  },
+                        { label: 'Original', value: 'Original' },
+                    ]"
+                    info="How to adapt input image dimensions to the requested image size. No Scale: do not scale, just crop or pad each dimension to fit (default behavior). Scale and Crop: scale to match the smaller dimension, preserving aspect ratio, then crop to fit. Scale and Pad: scale to match the larger dimension, preserving aspect ratio, then pad to fit. Stretch: stretch both dimensions to fit, possibly not preserving aspect ratio. Original: send the input image as-is to the server, with no scaling, cropping or padding."
+                />
                 <form-radio  label="Video Gen: Request AVI download" prop="pageless" v-model="store.alsoRequestAvi" :options="['Enabled', 'Disabled']" />
             </el-tab-pane>
             <el-tab-pane label="📷 Images">


### PR DESCRIPTION
Adds a few extra options to adapt the input image size to the requested generation dimensions, besides the current "no scaling, crop and pad as needed":

* send image as-is: mostly useful for reference images with edit models, since they usually do not demand them to be the same size, and cropping / padding could degrade the reference;
* scale and pad: scale the larger dimension to fit, then pad if needed;
* scale and crop: scale the smaller dimension to fit, then crop if needed;
* stretch, ignoring aspect ratio changes 

I've kept the selector in the Options tab, but maybe it could make more sense on the Generation view?