### PR TITLE
scheduler UI enhancements 

### DIFF
--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -109,7 +109,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         scheduler: {
             name: "Scheduler",
             state: "Enabled",
-            allowedStates: ["Disabled", "Enabled"],
+            allowedStates: ["Disabled", "Enabled", "Multiple"],
             selected: [params.value.scheduler],
             mapToParam: el => el.scheduler,
         },

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -200,7 +200,7 @@ export const useGeneratorStore = defineStore("generator", () => {
     const cfgList =      ref(arrayRange(minCfgScale.value, maxCfgScale.value, 0.5));
 
     const totalImageCount = computed(() => {
-        const multiCalc = (before: number, multiParam: IMultiSelectItem<any>, defaultMultiplier = 1) => before * (multiParam.state === "Multiple" ? multiParam.selected.length : defaultMultiplier);
+        const multiCalc = (before: number, multiParam: IMultiSelectItem<any>, defaultMultiplier = 1) => before * (multiParam.state === "Multiple" && multiParam.selected.length > 0 ? multiParam.selected.length : defaultMultiplier);
         const imageCount = params.value.n;
         const promptMatrixCount  = imageCount * promptMatrix().length;
         const multiSamplerCount   = multiCalc(promptMatrixCount,   multiSelect.value.sampler);

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -163,8 +163,20 @@ handleUrlParams();
                                 </el-tooltip>
                             </template>
                         </form-input>
-                        <form-select label="Sampler(s)"            prop="samplers"        v-model="store.multiSelect.sampler.selected"     :options="availableSamplers"  info="Multi-select enabled. Heun and DPM2 double generation time per step, but converge twice as fast." multiple v-if="store.multiSelect.sampler.state === 'Multiple'" />
-                        <form-select label="Sampler"               prop="sampler"         v-model="store.params.sampler_name"              :options="availableSamplers"  info="Heun and DPM2 double generation time per step, but converge twice as fast." v-else-if="store.multiSelect.sampler.state === 'Enabled'" />
+                        <el-row :gutter="10" v-if="true">
+                            <el-col :span="isMobile ? 24 : 12" v-if="store.multiSelect.sampler.state === 'Multiple'">
+                                <form-select label="Sampler(s)"            prop="samplers"        v-model="store.multiSelect.sampler.selected"     :options="availableSamplers"  info="Multi-select enabled. Heun and DPM2 double generation time per step, but converge twice as fast." multiple />
+                            </el-col>
+                            <el-col :span="isMobile ? 24 : 12" v-if="store.multiSelect.sampler.state === 'Enabled'">
+                                <form-select label="Sampler"               prop="sampler"         v-model="store.params.sampler_name"              :options="availableSamplers"  info="Heun and DPM2 double generation time per step, but converge twice as fast." />
+                            </el-col>
+                            <el-col :span="isMobile ? 24 : 12" v-if="store.multiSelect.scheduler.state === 'Multiple'">
+                                <form-select label="Scheduler(s)"         prop="schedulers"      v-model="store.multiSelect.scheduler.selected"    :options="availableSchedulers" info="Multi-select enabled. Experimental! KoboldCpp only, allows you to use a different scheduler. Leave as default otherwise." multiple />
+                            </el-col>
+                            <el-col :span="isMobile ? 24 : 12" v-if="store.multiSelect.scheduler.state === 'Enabled'">
+                                <form-select label="Scheduler"             prop="scheduler"       v-model="store.params.scheduler"            :options="availableSchedulers" info="Experimental! KoboldCpp only, allows you to use a different scheduler. Leave as default otherwise." />
+                            </el-col>
+                        </el-row>
                         <form-slider label="Batch Size"            prop="batchSize"       v-model="store.params.n"                         :min="store.minImages"        :max="store.maxImages" />
                         <form-slider label="Steps(s)"              prop="multiSteps"      v-model="store.multiSelect.steps.selected"       :min="store.minSteps"         :max="store.maxSteps"      info="Multi-select enabled. Keep step count between 30 to 50 for optimal generation times. Coherence typically peaks between 60 and 90 steps, with a trade-off in speed." multiple v-if="store.multiSelect.steps.state === 'Multiple'" />
                         <form-slider label="Steps"                 prop="steps"           v-model="store.params.steps"                     :min="store.minSteps"         :max="store.maxSteps"      info="Keep step count between 30 to 50 for optimal generation times. Coherence typically peaks between 60 and 90 steps, with a trade-off in speed." v-else-if="store.multiSelect.steps.state === 'Enabled'" />
@@ -177,7 +189,6 @@ handleUrlParams();
                         <form-slider label="CLIP Skip"             prop="clipSkip"        v-model="store.params.clip_skip"                 :min="store.minClipSkip"      :max="store.maxClipSkip"   info="Last layers of CLIP to ignore. For most situations this can be left alone." v-else-if="store.multiSelect.clipSkip.state === 'Enabled'" />
                         <form-slider label="Init Strength"         prop="denoise"         v-model="store.params.denoising_strength"        :min="store.minDenoise"       :max="store.maxDenoise"    :step="0.01" info="The final image will diverge from the starting image at higher values. 0=unchanged, 1=fullychanged" v-if="store.sourceGeneratorTypes.includes(store.generatorType)" />
                         <form-slider label="Video Frames"          prop="frames"          v-model="store.params.frames"                    :min="store.minFrames"        :max="store.maxFrames"     info="Number of consecutive video frames to generate (Video models only). Max 80 frames, about 5 seconds of video."/>
-                        <form-select label="Scheduler"             prop="scheduler"       v-model="store.params.scheduler"            :options="availableSchedulers" info="Experimental! KoboldCpp only, allows you to use a different scheduler. Leave as default otherwise." v-if="store.multiSelect.scheduler.state === 'Enabled'"/>
                         <div>
                         <span style="height: 100%;font-size: 14px;">Reference Image: <br>(Photomaker/Kontext) </span>
                         <input class="el-button"


### PR DESCRIPTION
- move the scheduler control beside the sampler, to save a bit of vertical space
- enable multiple schedulers
- fix total image calculation with empty multiselect fields

And I _think_ I've figured out the problem with my build environment.