### PR TITLE
drop the ongoing image gen connection when aborting

### DIFF
--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -191,6 +191,7 @@ export const useGeneratorStore = defineStore("generator", () => {
     const generating = ref(false);
     const cancelled  = ref(false);
     const outputs    = ref<CarouselOutput[]>([]);
+    const abortController = ref<AbortController | null>(null);
     const queue = ref<ICurrentGeneration[]>([]);
     const lastImageGenkey = useLocalStorage("lastImageGenkey", "");
     const lastImageRecoveryUrl = computed(() => {
@@ -471,6 +472,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         }
 
         // Reset variables
+        abortController.value = new AbortController();
         cancelled.value = false;
 
         if (timer.value.interval) {
@@ -490,7 +492,7 @@ export const useGeneratorStore = defineStore("generator", () => {
             if (!next) break;
             next.gathered = true;
             try {
-                const res = await fetchNewID(next.params);
+                const res = await fetchNewID(next.params, abortController.value?.signal);
                 if (!res) {
                     next.failed = true;
                     continue;
@@ -719,7 +721,7 @@ export const useGeneratorStore = defineStore("generator", () => {
     /**
      * Fetches a new ID
      */
-    async function fetchNewID(parameters: any) {
+    async function fetchNewID(parameters: any, signal?: AbortSignal) {
         const optionsStore = useOptionsStore();
         try {
             const genkey = getNewGenkey();
@@ -733,7 +735,8 @@ export const useGeneratorStore = defineStore("generator", () => {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify(requestParameters)
+                body: JSON.stringify(requestParameters),
+                signal
             })
             const resJSON = await response.json();
             if (!validateResponse(response, resJSON, 200, "Failed to fetch", onInvalidResponse)) return false;
@@ -919,6 +922,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         img2img,
         uploadDimensions,
         cancelled,
+        abortController,
         multiSelect,
         referenceImages,
         negativePrompt,

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -322,6 +322,7 @@ handleUrlParams();
                     style="width: 25%;"
                     :disabled="store.cancelled"
                     @click="() => {
+                        store.abortController?.abort();
                         store.cancelled = true;
                         store.generating = false;
                         store.clearQueue();


### PR DESCRIPTION
So the server will eventually be able to detect it, and abort the gen. Right now, it only reports:

> generate_image completed in 11.82s[11:39:34] Generating Media Complete
127.0.0.1 - - [09/Jul/2026 11:39:34] "POST /sdapi/v1/txt2img HTTP/1.1" 200 -
[Errno 32] Broken pipe
Generate Image: The response could not be sent, maybe connection was terminated?