### PR TITLE
fix: clean up queue when the server disconnects

### DIFF
--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -514,6 +514,7 @@ export const useGeneratorStore = defineStore("generator", () => {
             clearInterval(timer.value.interval);
             timer.value.interval = 0;
             timer.value.seconds = 0;
+            queue.value = [];
         }
 
         if (DEBUG_MODE) console.log("Images queued");


### PR DESCRIPTION
Tested by restarting the server during an ongoing generation: on the next request, the previously queued up items would still be counted, and the queue would never clean up on its own.