### PR TITLE
generation progress and image preview

### DIFF
--- a/src/components/ImageProgress.vue
+++ b/src/components/ImageProgress.vue
@@ -5,10 +5,17 @@ import { useEllipsis } from '@/utils/useEllipsis';
 
 const { ellipsis } = useEllipsis();
 
+const truncate = (text: string | null | undefined, maxLen: number) => {
+    if (!text) return "";
+    return text.length > maxLen ? text.slice(0, maxLen) + "\u2026" : text;
+};
+
 defineProps<{
     generated?: number;
     total?: number;
     elapsed?: string;
+    progressPercentage?: number;
+    textInfo?: string | null;
 }>();
 
 defineEmits(["showGenerated"]);
@@ -18,16 +25,20 @@ defineEmits(["showGenerated"]);
     <div style="text-align: center;">
         <el-progress
             type="circle"
-            :percentage="100 * (generated ?? 0) / (total ?? 1)"
+            :percentage="progressPercentage ?? (100 * (generated ?? 0) / (total ?? 1))"
             :width="200"
         >
             <template #default>
-                <span>{{ generated }} / {{ total }}</span><br>
+                <span v-if="progressPercentage !== undefined">{{ progressPercentage }}%</span>
+                <span v-else>{{ generated }} / {{ total }}</span><br>
             </template>
         </el-progress>
         <div class="gen-text">
             <span v-if="generated === total">All done!</span>
-            <span v-else>Generating{{ellipsis}}{{'&nbsp;'.repeat(3 - ellipsis.length)}}<br><sup>{{ elapsed }}</sup></span>
+            <span v-else>
+                <span v-if="textInfo">{{ truncate(textInfo, 60) }}</span>
+                <span v-else>Generating{{ellipsis}}{{'&nbsp;'.repeat(3 - ellipsis.length)}}<br><sup>{{ elapsed }}</sup></span>
+            </span>
         </div>
         <div @click="$emit('showGenerated')" v-if="generated" class="view-images">
             <span>View image{{ total === 1 ? "" : "s" }}</span>

--- a/src/components/ImageProgress.vue
+++ b/src/components/ImageProgress.vue
@@ -16,6 +16,10 @@ defineProps<{
     elapsed?: string;
     progressPercentage?: number;
     textInfo?: string | null;
+    currentStep?: number;
+    totalSteps?: number;
+    previewImage?: string | null; // Expects raw base64 string
+    generating?: boolean;
 }>();
 
 defineEmits(["showGenerated"]);
@@ -23,31 +27,82 @@ defineEmits(["showGenerated"]);
 
 <template>
     <div style="text-align: center;">
+
+        <div class="batch-text" v-if="generating && total && total > 1">
+            Image {{ (generated ?? 0) + 1 }} of {{ total }}
+        </div>
+
         <el-progress
             type="circle"
             :percentage="progressPercentage ?? (100 * (generated ?? 0) / (total ?? 1))"
             :width="200"
         >
             <template #default>
-                <span v-if="progressPercentage !== undefined">{{ progressPercentage }}%</span>
-                <span v-else>{{ generated }} / {{ total }}</span><br>
+                <!-- If we have step data, show step count inside the circle -->
+                <span v-if="progressPercentage !== undefined && progressPercentage > 0" class="step-text">
+                    {{ currentStep ?? 0 }} / {{ totalSteps ?? 0 }}
+                </span>
+                <!-- Fallback to batch count if no step data is available -->
+                <span v-else>{{ generated ?? 0 }} / {{ total ?? 1 }}</span>
             </template>
         </el-progress>
-        <div class="gen-text">
-            <span v-if="generated === total">All done!</span>
-            <span v-else>
-                <span v-if="textInfo">{{ truncate(textInfo, 60) }}</span>
-                <span v-else>Generating{{ellipsis}}{{'&nbsp;'.repeat(3 - ellipsis.length)}}<br><sup>{{ elapsed }}</sup></span>
-            </span>
-        </div>
+
         <div @click="$emit('showGenerated')" v-if="generated" class="view-images">
-            <span>View image{{ total === 1 ? "" : "s" }}</span>
+            <span>View image{{ (total ?? 1) === 1 ? "" : "s" }}</span>
             <el-icon><Right /></el-icon>
         </div>
+
+        <div class="gen-text">
+            <span v-if="generated !== undefined && total !== undefined && generated === total && generated > 0">All done!</span>
+            <span v-else-if="textInfo">{{ truncate(textInfo, 60) }}</span>
+            <span v-else>Generating{{ellipsis}}{{'&nbsp;'.repeat(3 - ellipsis.length)}}<br><sup>{{ elapsed }}</sup></span>
+        </div>
+        <div v-if="previewImage" class="preview-container">
+            <img 
+                :src="`data:image/png;base64,${previewImage}`" 
+                class="preview-img" 
+                alt="Generation Preview" 
+            />
+        </div>
+
     </div>
 </template>
 
 <style scoped>
+.batch-text {
+    font-size: 14px;
+    color: var(--el-color-info);
+    margin-bottom: 8px;
+    font-weight: 500;
+}
+
+.step-text {
+    font-weight: 500;
+}
+
+.preview-container {
+    margin-top: 12px;
+    display: flex;
+    justify-content: center;
+}
+
+.preview-img {
+    max-width: 200px;
+    max-height: 200px;
+    width: auto;
+    height: auto;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    border: 1px solid var(--el-border-color-lighter);
+    /* Smooth fade-in so the image doesn't harshly pop */
+    animation: fadeIn 0.2s ease-in-out;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0.6; }
+    to { opacity: 1; }
+}
+
 .view-images, .gen-text {
     display: flex;
     align-items: center;
@@ -60,6 +115,7 @@ defineEmits(["showGenerated"]);
 
 .gen-text {
     font-weight: 400;
+    min-height: 40px; /* Prevents layout jump when text changes */
 }
 
 .view-images:hover {

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -116,6 +116,9 @@ export const useGeneratorStore = defineStore("generator", () => {
     const progressInfo = ref<{
         percentage: number;
         textInfo: string | null;
+        currentStep: number;
+        totalSteps: number;
+        previewImage: string | null;
     } | null>(null);
     const progressInterval = ref<number | NodeJS.Timeout>(0);
     const multiSelect = ref<IMultiSelect>({
@@ -928,25 +931,61 @@ export const useGeneratorStore = defineStore("generator", () => {
     }
 
     // --- Progress polling ---
+    const lastPreviewKey = ref("");
+    const lastPreviewStep = ref(-1);
     async function fetchProgressInfo(): Promise<void> {
         const optionsStore = useOptionsStore();
         const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
         try {
-            const response = await fetch(`${baseUrl}/sdapi/v1/progress?skip_current_image=true`);
+            // lightweight poll for numbers
+            const response = await fetch(`${baseUrl}/sdapi/v1/progress?skip_current_image=true&genkey=${encodeURIComponent(lastImageGenkey.value)}`);
             if (!response.ok) return;
             const data = await response.json();
+            if (DEBUG_MODE) console.error('progressInfo:', data);
+
             progressInfo.value = {
                 percentage: Math.round((data.progress ?? 0) * 100),
                 textInfo: data.textinfo || null,
+                currentStep: data.state?.sampling_step ?? 0,
+                totalSteps: data.state?.sampling_steps ?? 0,
+                previewImage: progressInfo.value?.previewImage ?? null
             };
+
+            if (lastPreviewKey.value != lastImageGenkey.value) {
+                lastPreviewKey.value = lastImageGenkey.value;
+                lastPreviewStep.value = -1;
+            }
+
+            const currentStep = data.state?.sampling_step ?? 0;
+            if (lastPreviewStep.value != currentStep) {
+                lastPreviewStep.value = currentStep;
+                // Only fetch preview image if enabled
+                if (optionsStore.previewImageOnProgress === "Enabled") {
+                    fetchPreviewImage(baseUrl);
+                }
+            }
         } catch {
-            // Silently ignore - progress endpoint may not be available
+            // progress endpoint may not be available
+        }
+    }
+
+    async function fetchPreviewImage(baseUrl: string): Promise<void> {
+        try {
+            const response = await fetch(`${baseUrl}/sdapi/v1/progress?genkey=${encodeURIComponent(lastImageGenkey.value)}`);
+            if (!response.ok) return;
+            const data = await response.json();
+            if (data.current_image && progressInfo.value) {
+                progressInfo.value.previewImage = data.current_image;
+            }
+        } catch {
+            // progress endpoint may not be available
         }
     }
 
     function startProgressPolling(): void {
+        lastPreviewKey.value = '';
         if (progressInterval.value) return;
-        progressInfo.value = { percentage: 0, textInfo: null };
+        progressInfo.value = { percentage: 0, textInfo: null, currentStep: 0, totalSteps: 0, previewImage: null };
         progressInterval.value = setInterval(fetchProgressInfo, 1000);
     }
 

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -959,8 +959,8 @@ export const useGeneratorStore = defineStore("generator", () => {
             const currentStep = data.state?.sampling_step ?? 0;
             if (lastPreviewStep.value != currentStep) {
                 lastPreviewStep.value = currentStep;
-                // Only fetch preview image if enabled
-                if (optionsStore.previewImageOnProgress === "Enabled") {
+                // Only fetch preview image if set to "Image"
+                if (optionsStore.fetchGenerationProgress === "Image") {
                     fetchPreviewImage(baseUrl);
                 }
             }
@@ -985,6 +985,8 @@ export const useGeneratorStore = defineStore("generator", () => {
     function startProgressPolling(): void {
         lastPreviewKey.value = '';
         if (progressInterval.value) return;
+        // Skip polling if set to "Off"
+        if (useOptionsStore().fetchGenerationProgress === "Off") return;
         progressInfo.value = { percentage: 0, textInfo: null, currentStep: 0, totalSteps: 0, previewImage: null };
         progressInterval.value = setInterval(fetchProgressInfo, 1000);
     }

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -113,6 +113,11 @@ export const useGeneratorStore = defineStore("generator", () => {
         interval: 0 as number | NodeJS.Timeout,
         seconds: 0 as number,
     });
+    const progressInfo = ref<{
+        percentage: number;
+        textInfo: string | null;
+    } | null>(null);
+    const progressInterval = ref<number | NodeJS.Timeout>(0);
     const multiSelect = ref<IMultiSelect>({
         sampler: {
             name: "Sampler",
@@ -489,6 +494,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         timer.value.interval = setInterval(() => {
             timer.value.seconds++;
         }, 1000);
+        startProgressPolling();
 
         // Loop until queue is done or generation is cancelled
         while (!queue.value.every(el => el.gathered || el.failed) && !cancelled.value) {
@@ -514,6 +520,7 @@ export const useGeneratorStore = defineStore("generator", () => {
             clearInterval(timer.value.interval);
             timer.value.interval = 0;
             timer.value.seconds = 0;
+            stopProgressPolling();
             queue.value = [];
         }
 
@@ -600,6 +607,7 @@ export const useGeneratorStore = defineStore("generator", () => {
             clearInterval(timer.value.interval);
             timer.value.interval = 0;
             timer.value.seconds = 0;
+            stopProgressPolling();
         }
 
         return finalParams;
@@ -919,6 +927,37 @@ export const useGeneratorStore = defineStore("generator", () => {
         }
     }
 
+    // --- Progress polling ---
+    async function fetchProgressInfo(): Promise<void> {
+        const optionsStore = useOptionsStore();
+        const baseUrl = optionsStore.baseURL.length === 0 ? "." : optionsStore.baseURL;
+        try {
+            const response = await fetch(`${baseUrl}/sdapi/v1/progress?skip_current_image=true`);
+            if (!response.ok) return;
+            const data = await response.json();
+            progressInfo.value = {
+                percentage: Math.round((data.progress ?? 0) * 100),
+                textInfo: data.textinfo || null,
+            };
+        } catch {
+            // Silently ignore - progress endpoint may not be available
+        }
+    }
+
+    function startProgressPolling(): void {
+        if (progressInterval.value) return;
+        progressInfo.value = { percentage: 0, textInfo: null };
+        progressInterval.value = setInterval(fetchProgressInfo, 1000);
+    }
+
+    function stopProgressPolling(): void {
+        if (progressInterval.value) {
+            clearInterval(progressInterval.value);
+            progressInterval.value = 0;
+        }
+        progressInfo.value = null;
+    }
+
     return {
         // Variables
         generatorType,
@@ -958,6 +997,8 @@ export const useGeneratorStore = defineStore("generator", () => {
         queue,
         promptHistory,
         timer,
+        progressInfo,
+        progressInterval,
         lastImageGenkey,
         lastImageRecoveryUrl,
         lastImageRecoveryAvailable,
@@ -978,6 +1019,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         resetStore,
         clearQueue,
         clearOutputs,
+        stopProgressPolling,
         pushToNegativeLibrary,
         removeFromNegativeLibrary,
         pushToPromptHistory,

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -15,6 +15,7 @@ export const useOptionsStore = defineStore("options", () => {
     const allowLargerParams = useLocalStorage<IToggle>("allowLargerParams", "Disabled");
     const alsoRequestAvi = useLocalStorage<IToggle>("alsoRequestAvi", "Disabled");
     const keepImageGenOnDisconnect = useLocalStorage<IToggle>("keepImageGenOnDisconnect", "Disabled");
+    const previewImageOnProgress = useLocalStorage<IToggle>("previewImageOnProgress", "Disabled");
     const autoCarousel = useLocalStorage<IToggle>("autoCarousel", "Enabled");
     const useBeta = useLocalStorage<IToggle>("useBeta", "Disabled");
     const imageDownloadType = useLocalStorage<"WEBP" | "PNG" | "JPG" | "GIF" >("imageDownloadType", "PNG")
@@ -35,6 +36,7 @@ export const useOptionsStore = defineStore("options", () => {
         allowLargerParams,
         alsoRequestAvi,
         keepImageGenOnDisconnect,
+        previewImageOnProgress,
         autoCarousel,
         useBeta,
         imageDownloadType,

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -3,6 +3,7 @@ import { useColorMode, useLocalStorage, type BasicColorSchema } from '@vueuse/co
 import { ref } from 'vue';
 
 type IToggle = "Enabled" | "Disabled";
+type IPreviewImageOnProgress = "Off" | "Text" | "Image";
 
 export const useOptionsStore = defineStore("options", () => {
     const options = useLocalStorage("options", ref({
@@ -15,7 +16,7 @@ export const useOptionsStore = defineStore("options", () => {
     const allowLargerParams = useLocalStorage<IToggle>("allowLargerParams", "Disabled");
     const alsoRequestAvi = useLocalStorage<IToggle>("alsoRequestAvi", "Disabled");
     const keepImageGenOnDisconnect = useLocalStorage<IToggle>("keepImageGenOnDisconnect", "Disabled");
-    const previewImageOnProgress = useLocalStorage<IToggle>("previewImageOnProgress", "Disabled");
+    const fetchGenerationProgress = useLocalStorage<IPreviewImageOnProgress>("fetchGenerationProgress", "Off");
     const autoCarousel = useLocalStorage<IToggle>("autoCarousel", "Enabled");
     const useBeta = useLocalStorage<IToggle>("useBeta", "Disabled");
     const imageDownloadType = useLocalStorage<"WEBP" | "PNG" | "JPG" | "GIF" >("imageDownloadType", "PNG")
@@ -36,7 +37,7 @@ export const useOptionsStore = defineStore("options", () => {
         allowLargerParams,
         alsoRequestAvi,
         keepImageGenOnDisconnect,
-        previewImageOnProgress,
+        fetchGenerationProgress,
         autoCarousel,
         useBeta,
         imageDownloadType,

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -327,6 +327,7 @@ handleUrlParams();
                         store.generating = false;
                         store.clearQueue();
                         store.clearLastImageGenkey();
+                        store.stopProgressPolling();
                     }"
                 >Cancel all</el-button>
             </div>
@@ -342,6 +343,8 @@ handleUrlParams();
                         :generated="store.outputs.length"
                         :total="store.queue.length"
                         :elapsed="formatEST(store.timer.seconds)"
+                        :progress-percentage="store.progressInfo?.percentage"
+                        :text-info="store.progressInfo?.textInfo"
                         @show-generated="uiStore.showGeneratedImages = true"
                         v-if="!uiStore.showGeneratedImages && store.generating"
                     />

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -345,6 +345,10 @@ handleUrlParams();
                         :elapsed="formatEST(store.timer.seconds)"
                         :progress-percentage="store.progressInfo?.percentage"
                         :text-info="store.progressInfo?.textInfo"
+                        :current-step="store.progressInfo?.currentStep"
+                        :total-steps="store.progressInfo?.totalSteps"
+                        :preview-image="store.progressInfo?.previewImage"
+                        :generating="store.generating"
                         @show-generated="uiStore.showGeneratedImages = true"
                         v-if="!uiStore.showGeneratedImages && store.generating"
                     />

--- a/src/views/OptionsView.vue
+++ b/src/views/OptionsView.vue
@@ -93,6 +93,7 @@ async function bulkDownload() {
                 </div>
                 <form-radio  label="Allow Larger Params" prop="pageless" v-model="store.allowLargerParams" :options="['Enabled', 'Disabled']" />
                 <form-radio  label="Keep generation on disconnect" prop="keepImageGenOnDisconnect" v-model="store.keepImageGenOnDisconnect" :options="['Enabled', 'Disabled']" info="By default, a client disconnect or an abort action causes the ongoing generation to be interrupted as soon as possible and discarded. Enabling this option overrides that behavior, allowing the generation to finish, and making the image available to be downloaded by the UI when ready." />
+                <form-radio  label="Show preview images" prop="previewImageOnProgress" v-model="store.previewImageOnProgress" :options="['Enabled', 'Disabled']" info="Request live previews of the image being generated. This can make generation a little bit slower." />
                 <form-select
                     label="Image Resize Mode"
                     prop="imageResizeMode"

--- a/src/views/OptionsView.vue
+++ b/src/views/OptionsView.vue
@@ -93,7 +93,7 @@ async function bulkDownload() {
                 </div>
                 <form-radio  label="Allow Larger Params" prop="pageless" v-model="store.allowLargerParams" :options="['Enabled', 'Disabled']" />
                 <form-radio  label="Keep generation on disconnect" prop="keepImageGenOnDisconnect" v-model="store.keepImageGenOnDisconnect" :options="['Enabled', 'Disabled']" info="By default, a client disconnect or an abort action causes the ongoing generation to be interrupted as soon as possible and discarded. Enabling this option overrides that behavior, allowing the generation to finish, and making the image available to be downloaded by the UI when ready." />
-                <form-radio  label="Show preview images" prop="previewImageOnProgress" v-model="store.previewImageOnProgress" :options="['Enabled', 'Disabled']" info="Request live previews of the image being generated. This can make generation a little bit slower." />
+                <form-radio  label="Fetch generation progres" prop="fetchGenerationProgress" v-model="store.fetchGenerationProgress" :options="['Off', 'Text', 'Image']" info="Off: no progress polling. Text: fetch textual progress info only. Image: fetch textual info and live image preview." />
                 <form-select
                     label="Image Resize Mode"
                     prop="imageResizeMode"


### PR DESCRIPTION
A basic implementation to show the current generation progress, with image preview.

Works together with LostRuins/koboldcpp#2316 .

<img width="329" height="473" alt="image" src="https://github.com/user-attachments/assets/ffefb3bc-3744-41fb-8ea4-e5dfba9efc27" />
