### PR TITLE
add LoRA control

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "preview": "vite preview --port 4173",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit",
-    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore"
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
+    "test": "node --test"
   },
   "engines": {
     "node": ">=22.18.0"

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -10,6 +10,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { DEBUG_MODE, MAX_PARALLEL_REQUESTS } from "@/constants";
 import { validateResponse } from "@/utils/validate";
 import { extractLorasFromPrompt } from "@/utils/loras";
+import { parsePromptSegments, expandPromptSegments } from "@/utils/expansions";
 import { convertToBase64 } from "@/utils/base64";
 import { buildApiUrl } from "@/utils/api";
 function getDefaultStore() {
@@ -711,32 +712,15 @@ export const useGeneratorStore = defineStore("generator", () => {
     }
 
     /**
-     * Returns all prompt matrix combinations
+     * Returns all prompt matrix combinations. Expansion is two-phase: the
+     * prompt is parsed into literal/expansion segments (an expansion ends at
+     * the first `}`, no nesting; a stray or unclosed brace is literal), then
+     * the segments are expanded via Cartesian product and concatenated — no
+     * string replacement, so options are used verbatim.
      */
     function promptMatrix() {
         const prompt = getFullPrompt();
-        const matrixMatches = prompt.match(/\{(.*?)\}/g) || [];
-        if (matrixMatches.length === 0) return [prompt];
-        let prompts: string[] = [];
-        matrixMatches.forEach(matrix => {
-            const newPrompts: string[] = [];
-            const options = matrix.replace("{", "").replace("}", "").split("|");
-            if (prompts.length === 0) {
-                options.forEach(option => {
-                    const newPrompt = prompt.replace(matrix, option);
-                    newPrompts.push(newPrompt);
-                });
-            } else {
-                prompts.forEach(previousPrompt => {
-                    options.forEach(option => {
-                        const newPrompt = previousPrompt.replace(matrix, option);
-                        newPrompts.push(newPrompt);
-                    });
-                });
-            }
-            prompts = [...newPrompts];
-        });
-        return prompts;
+        return expandPromptSegments(parsePromptSegments(prompt));
     }
 
     /**

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -725,19 +725,18 @@ export const useGeneratorStore = defineStore("generator", () => {
             const splitPrompt = data.prompt.split(" ### ");
             prompt.value = splitPrompt[0];
             negativePrompt.value = splitPrompt[1] || "";
-            // the restored prompt carries the stored <lora:> tags; zero any matching row of the
+            // the restored prompt carries the stored <lora:> tags; remove any matching row of the
             // non-persisted LoRA list, so regenerating doesn't apply the row's multiplier on top of
             // the tag it was stored from
             const [, restoredLoras] = extractLorasFromPrompt(prompt.value);
             if (restoredLoras.length > 0) {
                 const availableLoras = (await fetchLoras()) ?? [];
-                for (const row of loraList.value) {
-                    if (!row.lora || row.lora.trim() === "") continue;
-                    const matches = restoredLoras.some(tag =>
+                loraList.value = loraList.value.filter(row => {
+                    if (!row.lora || row.lora.trim() === "") return true;
+                    return !restoredLoras.some(tag =>
                         tag.name === row.lora
                         || availableLoras.some(al => al.name === tag.name && al.path === row.lora));
-                    if (matches) row.multiplier = 0;
-                }
+                });
             }
         }
         if (data.sampler_name) {

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -85,6 +85,16 @@ type IReferenceImage = {
     base64: string;
 }
 
+/**
+ * A row of the non-persisted LoRA list on the generation screen
+ * */
+type ILoraListItem = {
+    /** Selected LoRA (the `path` from GET /sdapi/v1/loras, empty until one is picked) */
+    lora: string;
+    /** LoRA multiplier, sent in the lora field of the generation parameters */
+    multiplier: number;
+}
+
 interface IMultiSelect {
     sampler: IMultiSelectItem<string>;
     steps: IMultiSelectItem<number>;
@@ -264,6 +274,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         videoStartFrame.value = null;
         videoEndFrame.value = null;
         outputs.value = [];
+        loraList.value = [];
         useUIStore().showGeneratedImages = false;
         clearQueue();
         clearLastImageGenkey();
@@ -327,20 +338,50 @@ export const useGeneratorStore = defineStore("generator", () => {
 
         const availableLoras = (
             promptsAndLoras.some(ps => ps.extractedLoras.length > 0)
+                || loraList.value.some(row => row.lora && row.lora.trim() !== "")
             ? await fetchLoras() : []);
 
+        // build the structured lora entries from the (non-persisted) LoRA list on the generation screen;
+        // rows without a selected LoRA are ignored
+        const loraListRequests = loraList.value
+            .filter(row => row.lora && row.lora.trim() !== "")
+            .flatMap(row => {
+                const match = availableLoras.find(al => al.name === row.lora || al.path === row.lora);
+                // the lora field only accepts the LoRA's path, so skip entries that can't be resolved
+                if (!match) return [];
+                const multiplier = Number(row.multiplier);
+                return [{ path: match.path, multiplier: isNaN(multiplier) ? 0 : multiplier }];
+            });
+
+        // merge entries by resolved path and is_high_noise, accumulating the multipliers (the server behaves
+        // the same way with duplicate entries); entries with the same path but different is_high_noise are
+        // kept separate, as they apply to different generation phases
+        const mergeLoraEntries = (entries: { path: string; multiplier: number; is_high_noise?: boolean }[]) => {
+            const merged = new Map<string, { path: string; multiplier: number; is_high_noise?: boolean }>();
+            for (const entry of entries) {
+                const key = `${entry.path}\u0000${entry.is_high_noise ? 1 : 0}`;
+                const existing = merged.get(key);
+                if (existing) {
+                    existing.multiplier = Math.round((existing.multiplier + entry.multiplier) * 10000) / 10000;
+                } else {
+                    merged.set(key, { ...entry });
+                }
+            }
+            return [...merged.values()];
+        };
+
         const processedPrompts = promptsAndLoras.map(({ extractedLoras, ...ps }) => {
-            const loraRequest = (
-                extractedLoras.length > 0 && availableLoras.length > 0 ?
-                    extractedLoras.map(l => {
-                        const match = availableLoras.find(al => al.name === l.name || al.path === l.name);
-                        return {
-                            path: match ? match.path : l.name,
-                            multiplier: l.multiplier,
-                            ...(l.is_high_noise ? { is_high_noise: true } : {}),
-                        };
-                    }) : []
-            );
+            const promptLoraRequests = extractedLoras.flatMap(l => {
+                const match = availableLoras.find(al => al.name === l.name || al.path === l.name);
+                // the lora field only accepts the LoRA's path, so skip entries that can't be resolved
+                return match ? [{
+                    path: match.path,
+                    multiplier: l.multiplier,
+                    ...(l.is_high_noise ? { is_high_noise: true } : {}),
+                }] : [];
+            });
+            // no overlap with the LoRA list: it is simply appended; overlapping entries accumulate
+            const loraRequest = mergeLoraEntries([...promptLoraRequests, ...loraListRequests]);
 
             return {
                 ...ps,
@@ -860,6 +901,17 @@ export const useGeneratorStore = defineStore("generator", () => {
         return false;
     }
 
+    // --- Non-persisted LoRA list (name + multiplier pairs) on the generation screen ---
+    const loraList = ref<ILoraListItem[]>([]);
+
+    function addLoraRow() {
+        loraList.value = [...loraList.value, { lora: "", multiplier: 0 }];
+    }
+
+    function removeLoraRow(index: number) {
+        loraList.value = loraList.value.filter((_, i) => i !== index);
+    }
+
     const referenceImages = ref<IReferenceImage[]>([]);
 
     const videoStartFrame = ref<IReferenceImage | null>(null);
@@ -1056,6 +1108,9 @@ export const useGeneratorStore = defineStore("generator", () => {
         referenceImages,
         videoStartFrame,
         videoEndFrame,
+        loraList,
+        addLoraRow,
+        removeLoraRow,
         negativePrompt,
         generating,
         negativePromptLibrary,
@@ -1119,6 +1174,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         clearVideoEndFrame,
         getAvailableSamplers,
         getAvailableSchedulers,
+        fetchLoras,
         cacheVersion,
         invalidateApiCaches,
         getCachedEndpoint

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -291,14 +291,15 @@ export const useGeneratorStore = defineStore("generator", () => {
     }
 
     /**
-     * Fetches available LoRAs from the server
+     * Fetches available LoRAs from the server. The result is cached per server
+     * baseURL (see getCachedEndpoint), so repeated calls (the generation screen's
+     * lazy panel fetch and generateImage) share a single round-trip. Resolves to
+     * the list (which may be empty), or to null if the request failed (a failed
+     * fetch is not cached, so the next attempt retries)
      * */
-    async function fetchLoras(): Promise<any[]> {
-        const optionsStore = useOptionsStore();
-        const response = await fetch(buildApiUrl(optionsStore.baseURL, "/sdapi/v1/loras"));
-        const resJSON = await response.json();
-        if (!validateResponse(response, resJSON, 200, "Failed to get available LoRAs")) return [];
-        return resJSON;
+    async function fetchLoras(): Promise<any[] | null> {
+        const result = await getCachedEndpoint<any[]>("/sdapi/v1/loras");
+        return Array.isArray(result) ? result : null;
     }
 
     /**
@@ -339,7 +340,7 @@ export const useGeneratorStore = defineStore("generator", () => {
         const availableLoras = (
             promptsAndLoras.some(ps => ps.extractedLoras.length > 0)
                 || loraList.value.some(row => row.lora && row.lora.trim() !== "")
-            ? await fetchLoras() : []);
+            ? (await fetchLoras() ?? []) : []);
 
         // build the structured lora entries from the (non-persisted) LoRA list on the generation screen;
         // rows without a selected LoRA are ignored

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -321,17 +321,17 @@ export const useGeneratorStore = defineStore("generator", () => {
         // Cache parameters so the user can't mutate the output data while it's generating
         const paramsCached: any[] = [];
 
-        // split "###" and {|} syntax
+        // split "###" and {|} syntax; the negative prompt is never scanned for LoRA tags, so any
+        // tag inside it is inert and is sent and stored as-is
         const processedRawPrompts = promptMatrix().map(ps => {
             const p = ps.split(" ### ");
             return {
-                full_prompt: ps,
                 prompt: p[0],
                 negative_prompt: p[1] || ""
             };
         });
 
-        // extract <lora:name:value> and build the lora field
+        // extract <lora:name:value> from the positive prompt
         const promptsAndLoras = processedRawPrompts.map(ps => {
             const [cleanedPrompt, extractedLoras] = extractLorasFromPrompt(ps.prompt);
             return { ...ps, prompt: cleanedPrompt, extractedLoras: extractedLoras };
@@ -342,25 +342,25 @@ export const useGeneratorStore = defineStore("generator", () => {
                 || loraList.value.some(row => row.lora && row.lora.trim() !== "")
             ? (await fetchLoras() ?? []) : []);
 
-        // build the structured lora entries from the (non-persisted) LoRA list on the generation screen;
-        // rows without a selected LoRA are ignored
-        const loraListRequests = loraList.value
+        // the raw LoRA entries from the (non-persisted) LoRA list on the generation screen; rows
+        // without a selected LoRA are ignored. The entry's name is the LoRA's display name when the
+        // row can be resolved, the row's raw value otherwise (preserved as an inert tag)
+        const loraListEntries = loraList.value
             .filter(row => row.lora && row.lora.trim() !== "")
             .flatMap(row => {
                 const match = availableLoras.find(al => al.name === row.lora || al.path === row.lora);
-                // the lora field only accepts the LoRA's path, so skip entries that can't be resolved
-                if (!match) return [];
                 const multiplier = Number(row.multiplier);
-                return [{ path: match.path, multiplier: isNaN(multiplier) ? 0 : multiplier }];
+                return [{ name: match ? match.name : row.lora, multiplier: isNaN(multiplier) ? 0 : multiplier }];
             });
 
-        // merge entries by resolved path and is_high_noise, accumulating the multipliers (the server behaves
-        // the same way with duplicate entries); entries with the same path but different is_high_noise are
-        // kept separate, as they apply to different generation phases
-        const mergeLoraEntries = (entries: { path: string; multiplier: number; is_high_noise?: boolean }[]) => {
-            const merged = new Map<string, { path: string; multiplier: number; is_high_noise?: boolean }>();
+        // merge entries by (name, is_high_noise), accumulating the multipliers (the server accumulates
+        // the same way for duplicate entries); entries with different is_high_noise are kept separate,
+        // as they apply to different generation phases
+        const mergeLoraEntries = (entries: { name: string; multiplier: number; is_high_noise?: boolean }[]) => {
+            const merged = new Map<string, { name: string; multiplier: number; is_high_noise?: boolean }>();
             for (const entry of entries) {
-                const key = `${entry.path}\u0000${entry.is_high_noise ? 1 : 0}`;
+                if (!entry.name || entry.name.trim() === "") continue;
+                const key = `${entry.name}\u0000${entry.is_high_noise ? 1 : 0}`;
                 const existing = merged.get(key);
                 if (existing) {
                     existing.multiplier = Math.round((existing.multiplier + entry.multiplier) * 10000) / 10000;
@@ -372,20 +372,47 @@ export const useGeneratorStore = defineStore("generator", () => {
         };
 
         const processedPrompts = promptsAndLoras.map(({ extractedLoras, ...ps }) => {
-            const promptLoraRequests = extractedLoras.flatMap(l => {
-                const match = availableLoras.find(al => al.name === l.name || al.path === l.name);
-                // the lora field only accepts the LoRA's path, so skip entries that can't be resolved
-                return match ? [{
-                    path: match.path,
+            // R: the raw LoRA list (the prompt's tags first, then the screen's rows) — everything that
+            // was requested, including zero-multiplier and unresolvable entries, which are preserved
+            // as inert <lora:> tags in the image metadata, but not sent to the server
+            const rawLoraEntries = mergeLoraEntries([
+                ...extractedLoras.map(l => ({
+                    name: l.name,
                     multiplier: l.multiplier,
                     ...(l.is_high_noise ? { is_high_noise: true } : {}),
+                })),
+                ...loraListEntries,
+            ]);
+
+            // G: what is actually sent to the server — zero-multiplier and unresolvable entries are
+            // filtered out, and each name is resolved to the LoRA's path; two names resolving to the
+            // same path are both sent (the server accumulates duplicate paths)
+            const loraRequest = rawLoraEntries.flatMap(entry => {
+                if (entry.multiplier === 0) return [];
+                const match = availableLoras.find(al => al.name === entry.name || al.path === entry.name);
+                return match ? [{
+                    path: match.path,
+                    multiplier: entry.multiplier,
+                    ...(entry.is_high_noise ? { is_high_noise: true } : {}),
                 }] : [];
             });
-            // no overlap with the LoRA list: it is simply appended; overlapping entries accumulate
-            const loraRequest = mergeLoraEntries([...promptLoraRequests, ...loraListRequests]);
+
+            // the full prompt stored in the image metadata: the tag-free positive prompt with the raw
+            // LoRA list R appended as <lora:> tags (so a re-queued image re-requests the same LoRAs),
+            // then the untouched negative prompt. Space runs left behind by tag removal are collapsed
+            // (metadata only, the request prompt is unaffected), so the stored prompt stays clean and
+            // stable across re-queue/regeneration cycles
+            const loraTags = rawLoraEntries.map(e =>
+                `<lora:${e.is_high_noise ? "|high_noise|" : ""}${e.name}:${String(Math.round(e.multiplier * 10000) / 10000)}>`);
+            const cleanedPositive = loraTags.length > 0 ? ps.prompt.replace(/ +/g, " ").trim() : ps.prompt;
+            const taggedPrompt = [cleanedPositive, loraTags.join(" ")]
+                .filter(s => s !== "")
+                .join(" ");
+            const full_prompt = ps.negative_prompt !== "" ? `${taggedPrompt} ### ${ps.negative_prompt}` : taggedPrompt;
 
             return {
                 ...ps,
+                full_prompt,
                 ...(loraRequest.length > 0 ? { lora: loraRequest } : {})
             };
         });
@@ -698,6 +725,20 @@ export const useGeneratorStore = defineStore("generator", () => {
             const splitPrompt = data.prompt.split(" ### ");
             prompt.value = splitPrompt[0];
             negativePrompt.value = splitPrompt[1] || "";
+            // the restored prompt carries the stored <lora:> tags; zero any matching row of the
+            // non-persisted LoRA list, so regenerating doesn't apply the row's multiplier on top of
+            // the tag it was stored from
+            const [, restoredLoras] = extractLorasFromPrompt(prompt.value);
+            if (restoredLoras.length > 0) {
+                const availableLoras = (await fetchLoras()) ?? [];
+                for (const row of loraList.value) {
+                    if (!row.lora || row.lora.trim() === "") continue;
+                    const matches = restoredLoras.some(tag =>
+                        tag.name === row.lora
+                        || availableLoras.some(al => al.name === tag.name && al.path === row.lora));
+                    if (matches) row.multiplier = 0;
+                }
+            }
         }
         if (data.sampler_name) {
             params.value.sampler_name = data.sampler_name;

--- a/src/utils/expansions.ts
+++ b/src/utils/expansions.ts
@@ -1,0 +1,71 @@
+/**
+ * Prompt expansion (the `{a|b}` matrix syntax), split into two phases:
+ * 1. `parsePromptSegments`: the raw prompt is mapped to a list of segments —
+ *    literal text, or an expansion (a list of alternative strings), each
+ *    carrying its `[start, end)` range in the original prompt.
+ * 2. `expandPromptSegments`: the segments are expanded into the full list of
+ *    prompts (Cartesian product of the segment alternatives, concatenated).
+ *
+ * The segment list is the shared structure for anything that must distinguish
+ * literal text from to-be-expanded text (e.g. extracting LoRA tags only from
+ * literal segments, at positions in the original prompt).
+ */
+export type PromptSegment =
+    | { type: "literal"; text: string; start: number; end: number }
+    | { type: "expansion"; options: string[]; start: number; end: number };
+
+/**
+ * Splits a prompt into literal and expansion segments.
+ *
+ * - a `{...}` expansion ends at the *first* `}` (no nesting support — this
+ *   mirrors the historical `/\{(.*?)\}/g` behavior; a nested `{` is just
+ *   part of an option's text);
+ * - a `{` with no closing `}` is literal, along with everything after it;
+ * - a stray `}` is literal.
+ *
+ * @param prompt The raw prompt string.
+ * @returns The list of segments, in order, covering the whole prompt.
+ */
+export function parsePromptSegments(prompt: string): PromptSegment[] {
+    const segments: PromptSegment[] = [];
+    let literalStart = 0;
+    for (let i = 0; i < prompt.length; i++) {
+        if (prompt[i] !== "{") continue;
+        if (i > literalStart) {
+            segments.push({ type: "literal", text: prompt.slice(literalStart, i), start: literalStart, end: i });
+        }
+        const end = prompt.indexOf("}", i + 1);
+        if (end === -1) {
+            // unclosed brace: the brace (and the rest of the prompt) is literal
+            segments.push({ type: "literal", text: prompt.slice(i), start: i, end: prompt.length });
+            literalStart = prompt.length;
+            break;
+        }
+        segments.push({ type: "expansion", options: prompt.slice(i + 1, end).split("|"), start: i, end: end + 1 });
+        literalStart = end + 1;
+        i = end; // the loop increment moves past the closing '}'
+    }
+    if (literalStart < prompt.length) {
+        segments.push({ type: "literal", text: prompt.slice(literalStart), start: literalStart, end: prompt.length });
+    }
+    return segments;
+}
+
+/**
+ * Expands a list of segments into all the resulting prompts (Cartesian
+ * product of the segment alternatives, concatenated). A literal segment
+ * contributes its text as a single alternative.
+ *
+ * @param segments The segments of a parsed prompt.
+ * @returns All the expanded prompts (a list with one entry for prompts
+ *          without any expansion).
+ */
+export function expandPromptSegments(segments: PromptSegment[]): string[] {
+    return segments.reduce<string[][]>(
+        (acc, segment) => {
+            const alternatives = segment.type === "literal" ? [segment.text] : segment.options;
+            return acc.flatMap(prev => alternatives.map(option => [...prev, option]));
+        },
+        [[]]
+    ).map(parts => parts.join(""));
+}

--- a/src/utils/loras.ts
+++ b/src/utils/loras.ts
@@ -1,3 +1,5 @@
+import type { PromptSegment } from "./expansions";
+
 export interface ILoraData {
   name: string;
   multiplier: number;
@@ -41,4 +43,129 @@ export function extractLorasFromPrompt(prompt: string): [string, ILoraData[]] {
   });
 
   return [updatedPrompt, loraData];
+}
+
+/**
+ * An entry extracted from a prompt's <lora:> tag, ready to be turned into a
+ * row of the generation screen's (non-persisted) LoRA list
+ */
+export interface ILoraRowEntry {
+  /** The tag's name (the tag text after `<lora:`, without the `|high_noise|` prefix) */
+  name: string;
+  /** The tag's weight, parsed as a number */
+  multiplier: number;
+}
+
+/**
+ * A row of the generation screen's (non-persisted) LoRA list, as far as the
+ * row allocation is concerned
+ */
+export interface ILoraRow {
+  /** The selected LoRA (the `path` from GET /sdapi/v1/loras, or a tag name that need not resolve to one) */
+  lora: string;
+  /** LoRA multiplier */
+  multiplier: number;
+}
+
+/**
+ * Extracts the LoRA tags of a prompt that can be turned into rows of the
+ * generation screen's (non-persisted) LoRA list — the inverse of what the
+ * screen's "To Prompt" button appends.
+ *
+ * Only the part of the prompt before the first `" ### "` separator is scanned
+ * (the remainder is never scanned for LoRA tags). A tag is converted only
+ * when all of these hold:
+ * - it is contained in a *literal* segment (tags inside `{a|b}` expansion
+ *   options would be altered by the expansion, so they stay in the prompt);
+ * - its weight is valid (parses as a number; an empty weight cannot match
+ *   the tag syntax at all);
+ * - it is not high noise (the `|high_noise|` prefix);
+ * - its name is not empty (a whitespace-only name counts as empty).
+ * The tag's name need not match a LoRA from the server's list.
+ *
+ * @param prompt The prompt (as in the generation screen's prompt field,
+ *               which may carry a `" ### "` separator).
+ * @param segments The segments of `parsePromptSegments(prompt)` (type-only
+ *                 import — this module stays runtime-independent from
+ *                 `./expansions`, so the framework-free Node test runner
+ *                 can load it).
+ * @returns [The prompt with the converted tags removed — space runs
+ *           collapsed and trimmed, the `" ### "` remainder preserved — and
+ *           the entries in the tags' prompt order]. The prompt is returned
+ *           unchanged when no tag is converted.
+ */
+export function extractLoraRowsFromPrompt(prompt: string, segments: PromptSegment[]): [string, ILoraRowEntry[]] {
+  const separatorIndex = prompt.indexOf(" ### ");
+  const positive = separatorIndex === -1 ? prompt : prompt.slice(0, separatorIndex);
+  const rest = separatorIndex === -1 ? "" : prompt.slice(separatorIndex);
+
+  const pattern = /<lora:([^:>]+):([^>]+)>/g;
+  const prefix = "|high_noise|";
+  const tags: { name: string; multiplier: number; start: number; end: number }[] = [];
+  for (const segment of segments) {
+    if (segment.type !== "literal") continue;
+    if (segment.start >= positive.length) break; // the segments tile the whole prompt
+    for (const match of segment.text.matchAll(pattern)) {
+      const tagIndex = match.index;
+      if (tagIndex === undefined) continue; // the type is optional, matchAll always sets it
+      const start = segment.start + tagIndex;
+      if (start >= positive.length) continue; // the tag starts in the unscanned remainder
+      const weight = Number(match[2]);
+      if (isNaN(weight)) continue; // invalid weight: keep the tag
+      const name = match[1];
+      if (name.startsWith(prefix)) continue; // high-noise tags are kept
+      if (name.trim() === "") continue; // empty name: keep the tag
+      tags.push({
+        name,
+        multiplier: weight,
+        start,
+        end: Math.min(start + match[0].length, positive.length),
+      });
+    }
+  }
+
+  if (tags.length === 0) return [prompt, []];
+
+  // remove the converted tags (last first, so the earlier offsets stay valid),
+  // collapse the space runs left behind, and trim — the `" ### "` remainder
+  // is preserved as-is
+  let cleaned = positive;
+  for (let i = tags.length - 1; i >= 0; i--) {
+    cleaned = cleaned.slice(0, tags[i].start) + cleaned.slice(tags[i].end);
+  }
+  return [
+    cleaned.replace(/ +/g, " ").trim() + rest,
+    tags.map(tag => ({ name: tag.name, multiplier: tag.multiplier })),
+  ];
+}
+
+/**
+ * Adds the given rows to the generation screen's (non-persisted) LoRA row
+ * list, reusing the trailing rows that are still empty (no selection and
+ * multiplier `0`) first — oldest first — and only appending new rows once
+ * that available space is used up. All other rows are left untouched.
+ *
+ * @param rows The current row list.
+ * @param incoming The rows to add.
+ * @returns A new row list (the input rows are shallow-copied, not mutated).
+ */
+export function allocateLoraRows(rows: ILoraRow[], incoming: ILoraRow[]): ILoraRow[] {
+  const result: ILoraRow[] = rows.map(row => ({ ...row }));
+  let firstTrailingEmpty = result.length;
+  while (
+    firstTrailingEmpty > 0
+    && result[firstTrailingEmpty - 1].lora === ""
+    && result[firstTrailingEmpty - 1].multiplier === 0
+  ) {
+    firstTrailingEmpty--;
+  }
+  incoming.forEach((entry, i) => {
+    const index = firstTrailingEmpty + i;
+    if (index < result.length) {
+      result[index] = { lora: entry.lora, multiplier: entry.multiplier };
+    } else {
+      result.push({ lora: entry.lora, multiplier: entry.multiplier });
+    }
+  });
+  return result;
 }

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -45,6 +45,8 @@ import { breakpointsTailwind, computedAsync, useBreakpoints } from '@vueuse/core
 import handleUrlParams from "@/router/handleUrlParams";
 import InterrogationView from '@/components/InterrogationView.vue';
 import { formatSeconds } from '@/utils/format';
+import { parsePromptSegments } from '@/utils/expansions';
+import { extractLoraRowsFromPrompt, allocateLoraRows } from '@/utils/loras';
 
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const isMobile = breakpoints.smallerOrEqual('md');
@@ -127,6 +129,27 @@ function moveLorasToPrompt() {
     });
     store.loraList = store.loraList.filter(row => !hasSelectedLora(row));
     store.prompt = store.prompt === "" ? tags.join(" ") : `${store.prompt} ${tags.join(" ")}`;
+}
+
+// moves the LoRA tags of the positive prompt into the (non-persisted) LoRA
+// list — the reverse of moveLorasToPrompt: each convertible tag becomes a row
+// (the trailing empty rows are reused first); tags inside {a|b} expansion
+// options, with an invalid weight, with the |high_noise| prefix, or with an
+// empty name are left in the prompt
+const promptLoraTagCount = computed(() => extractLoraRowsFromPrompt(store.prompt, parsePromptSegments(store.prompt))[1].length);
+
+function moveLorasFromPrompt() {
+    const [cleanedPrompt, extracted] = extractLoraRowsFromPrompt(store.prompt, parsePromptSegments(store.prompt));
+    if (extracted.length === 0) return;
+    const incoming = extracted.map(entry => {
+        // the row holds the LoRA's path when the server list is loaded (the
+        // row's select is optioned by path), the tag's raw name otherwise —
+        // generateImage resolves rows by name or path either way
+        const match = availableLoras.value.find(al => al.path === entry.name || al.name === entry.name);
+        return { lora: match ? match.path : entry.name, multiplier: entry.multiplier };
+    });
+    store.loraList = allocateLoraRows(store.loraList, incoming);
+    store.prompt = cleanedPrompt;
 }
 
 const rules = reactive<FormRules>({
@@ -312,6 +335,9 @@ handleUrlParams();
                             </el-button>
                             <el-button :icon="ArrowUp" @click="moveLorasToPrompt" :disabled="loraNamedCount === 0">
                                 To Prompt
+                            </el-button>
+                            <el-button :icon="ArrowDown" @click="moveLorasFromPrompt" :disabled="promptLoraTagCount === 0">
+                                From Prompt
                             </el-button>
                         </div>
                     </el-collapse-item>

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -109,6 +109,26 @@ const loraSummary = computed(() => {
         : `${enabled} enabled`;
 });
 
+const hasSelectedLora = (row: { lora: string }) => !!row.lora && row.lora.trim() !== "";
+const loraNamedCount = computed(() => store.loraList.filter(hasSelectedLora).length);
+
+// moves the rows with a selected LoRA out of the (non-persisted) LoRA list and appends
+// them to the positive prompt as <lora:name:weight> tags; rows without a selection stay
+function moveLorasToPrompt() {
+    const moving = store.loraList.filter(hasSelectedLora);
+    if (moving.length === 0) return;
+    const tags = moving.map(row => {
+        // the tag carries the LoRA's display name when the server list is loaded, the row's
+        // raw (path) value otherwise; both resolve later against GET /sdapi/v1/loras
+        const match = availableLoras.value.find(al => al.path === row.lora || al.name === row.lora);
+        const multiplier = Number(row.multiplier);
+        const weight = isNaN(multiplier) ? 0 : Math.round(multiplier * 10000) / 10000;
+        return `<lora:${match ? match.name : row.lora}:${weight}>`;
+    });
+    store.loraList = store.loraList.filter(row => !hasSelectedLora(row));
+    store.prompt = store.prompt === "" ? tags.join(" ") : `${store.prompt} ${tags.join(" ")}`;
+}
+
 const rules = reactive<FormRules>({
     prompt: [{
         required: true,
@@ -289,6 +309,9 @@ handleUrlParams();
                         <div class="lora-list-add">
                             <el-button :icon="Plus" @click="store.addLoraRow()" :disabled="availableLoras.length === 0">
                                 Add LoRA
+                            </el-button>
+                            <el-button :icon="ArrowUp" @click="moveLorasToPrompt" :disabled="loraNamedCount === 0">
+                                To Prompt
                             </el-button>
                         </div>
                     </el-collapse-item>

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import { useGeneratorStore, getNewSeed } from '@/stores/generator';
 import {
     type FormRules,
@@ -13,7 +13,10 @@ import {
     ElTooltip,
     ElRow,
     ElCol,
-    ElImage
+    ElImage,
+    ElSelect,
+    ElOption,
+    ElInputNumber
 } from 'element-plus';
 import {
     Comment,
@@ -23,6 +26,7 @@ import {
     ArrowUp,
     ArrowDown,
     Delete,
+    Plus,
 } from '@element-plus/icons-vue';
 import BrushFilled from '../components/icons/BrushFilled.vue';
 import ImageSearch from '../components/icons/ImageSearch.vue';
@@ -40,7 +44,6 @@ import { useCanvasStore } from '@/stores/canvas';
 import { breakpointsTailwind, computedAsync, useBreakpoints } from '@vueuse/core';
 import handleUrlParams from "@/router/handleUrlParams";
 import InterrogationView from '@/components/InterrogationView.vue';
-import { useOptionsStore } from '@/stores/options';
 import { formatSeconds } from '@/utils/format';
 
 const breakpoints = useBreakpoints(breakpointsTailwind);
@@ -49,7 +52,6 @@ const isMobile = breakpoints.smallerOrEqual('md');
 const store = useGeneratorStore();
 const uiStore = useUIStore();
 const canvasStore = useCanvasStore();
-const optionsStore = useOptionsStore();
 
 const availableSamplers = computedAsync(async () => {
     const _ignore     = store.cacheVersion; // force update when cached value changes
@@ -66,6 +68,23 @@ const availableSchedulers = computedAsync(async () => {
     if (schedulerList.length === 0) return [];
     return updateCurrentScheduler(schedulerList);
 }, [])
+
+// non-persisted LoRA list (name + multiplier pairs) on the generation screen
+const loraListOpen = ref<"" | "lora-list">("");
+const availableLoras = computedAsync(async () => {
+    const _ignore = store.cacheVersion; // force update when cached value changes
+    return store.fetchLoras();
+}, [])
+const loraSummary = computed(() => {
+    const enabled = store.loraList.filter(row => {
+        const multiplier = Number(row.multiplier);
+        return row.lora && row.lora.trim() !== "" && !isNaN(multiplier) && multiplier !== 0;
+    }).length;
+    const available = availableLoras.value.length;
+    return enabled === 0
+        ? `${available} available`
+        : `${enabled} enabled, ${available} available`;
+});
 
 const rules = reactive<FormRules>({
     prompt: [{
@@ -220,6 +239,37 @@ handleUrlParams();
                 <form-slider label="CLIP Skip(s)"          prop="clipSkips"       v-model="store.multiSelect.clipSkip.selected"    :min="store.minClipSkip"      :max="store.maxClipSkip"   info="Multi-select enabled. Last layers of CLIP to ignore. For most situations this can be left alone." multiple v-if="store.multiSelect.clipSkip.state === 'Multiple'" />
                 <form-slider label="CLIP Skip"             prop="clipSkip"        v-model="store.params.clip_skip"                 :min="store.minClipSkip"      :max="store.maxClipSkip"   info="Last layers of CLIP to ignore. For most situations this can be left alone." v-else-if="store.multiSelect.clipSkip.state === 'Enabled'" />
                 <form-slider label="Init Strength"         prop="denoise"         v-model="store.params.denoising_strength"        :min="store.minDenoise"       :max="store.maxDenoise"    :step="0.01" info="The final image will diverge from the starting image at higher values. 0=unchanged, 1=fullychanged" v-if="store.sourceGeneratorTypes.includes(store.generatorType)" />
+                <el-collapse v-model="loraListOpen" class="lora-list-collapse">
+                    <el-collapse-item name="lora-list">
+                        <template #title>
+                            <span class="lora-list-title">LoRAs</span>
+                            <span class="lora-list-summary">{{ loraSummary }}</span>
+                        </template>
+                        <div v-if="availableLoras.length === 0" class="lora-list-hint">
+                            No LoRAs were returned by the server.
+                        </div>
+                        <div v-for="(row, index) in store.loraList" :key="index" class="lora-list-row">
+                            <el-select v-model="row.lora" class="lora-list-select" filterable placeholder="Select a LoRA">
+                                <el-option value="" />
+                                <el-option
+                                    v-for="lora in availableLoras"
+                                    :key="lora.path"
+                                    :label="lora.name"
+                                    :value="lora.path"
+                                />
+                            </el-select>
+                            <el-input-number v-model="row.multiplier" :step="0.05" :precision="2" controls-position="right" />
+                            <el-tooltip content="Remove" placement="top">
+                                <el-button :icon="Delete" plain @click="store.removeLoraRow(index)" />
+                            </el-tooltip>
+                        </div>
+                        <div class="lora-list-add">
+                            <el-button :icon="Plus" @click="store.addLoraRow()" :disabled="availableLoras.length === 0">
+                                Add LoRA
+                            </el-button>
+                        </div>
+                    </el-collapse-item>
+                </el-collapse>
                 <form-slider label="Video Frames"          prop="frames"          v-model="store.params.frames"                    :min="store.minFrames"        :max="store.maxFrames"     info="Number of consecutive video frames to generate (Video models only). More frames increases memory usage."/>
                 <form-slider label="FPS"                   prop="fps"             v-model="store.params.fps"                       :min="store.minFps"           :max="store.maxFps"        :disabled="store.params.frames <= 1" info="Frames per second for video generation." v-if="store.params.frames > 1" />
                 <div
@@ -610,6 +660,44 @@ handleUrlParams();
     border-radius: 6px;
     color: var(--el-text-color-secondary);
     font-size: 13px;
+}
+
+.lora-list-collapse {
+    width: 100%;
+    margin: 14px 0;
+}
+
+.lora-list-title {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.lora-list-summary {
+    margin-left: 8px;
+    font-size: 13px;
+    color: var(--el-text-color-secondary);
+}
+
+.lora-list-hint {
+    padding: 4px 0;
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
+}
+
+.lora-list-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 0;
+}
+
+.lora-list-select {
+    flex: 1;
+    min-width: 140px;
+}
+
+.lora-list-add {
+    padding: 6px 0;
 }
 
 .video-frame-selectors {

--- a/src/views/GenerateView.vue
+++ b/src/views/GenerateView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
+import { computed, reactive, ref, watch } from 'vue';
 import { useGeneratorStore, getNewSeed } from '@/stores/generator';
 import {
     type FormRules,
@@ -69,21 +69,44 @@ const availableSchedulers = computedAsync(async () => {
     return updateCurrentScheduler(schedulerList);
 }, [])
 
-// non-persisted LoRA list (name + multiplier pairs) on the generation screen
+// non-persisted LoRA list (name + multiplier pairs) on the generation screen.
+// the server's LoRA list is fetched lazily: only if the panel is unfolded or
+// at least one LoRA row is enabled, to avoid the round-trip by default
 const loraListOpen = ref<"" | "lora-list">("");
-const availableLoras = computedAsync(async () => {
-    const _ignore = store.cacheVersion; // force update when cached value changes
-    return store.fetchLoras();
-}, [])
+const availableLoras = ref<any[]>([]);
+const loraListLoaded = ref(false);
+const loraListLoading = ref(false);
+
+function loadLoraList() {
+    if (loraListLoaded.value || loraListLoading.value) return;
+    loraListLoading.value = true;
+    store.fetchLoras().then(list => {
+        // a failed fetch (null) keeps the list unloaded, so the next attempt retries
+        if (list !== null) {
+            availableLoras.value = list;
+            loraListLoaded.value = true;
+        }
+    }).finally(() => { loraListLoading.value = false; });
+}
+
+const loraEnabledCount = computed(() => store.loraList.filter(row => {
+    const multiplier = Number(row.multiplier);
+    return row.lora && row.lora.trim() !== "" && !isNaN(multiplier) && multiplier !== 0;
+}).length);
+
+watch(
+    () => loraListOpen.value !== "" || loraEnabledCount.value > 0,
+    needed => { if (needed) loadLoraList(); },
+    { immediate: true },
+);
+
 const loraSummary = computed(() => {
-    const enabled = store.loraList.filter(row => {
-        const multiplier = Number(row.multiplier);
-        return row.lora && row.lora.trim() !== "" && !isNaN(multiplier) && multiplier !== 0;
-    }).length;
+    const enabled = loraEnabledCount.value;
     const available = availableLoras.value.length;
-    return enabled === 0
-        ? `${available} available`
-        : `${enabled} enabled, ${available} available`;
+    if (enabled === 0) return loraListLoaded.value ? `${available} available` : "";
+    return loraListLoaded.value
+        ? `${enabled} enabled, ${available} available`
+        : `${enabled} enabled`;
 });
 
 const rules = reactive<FormRules>({
@@ -245,7 +268,7 @@ handleUrlParams();
                             <span class="lora-list-title">LoRAs</span>
                             <span class="lora-list-summary">{{ loraSummary }}</span>
                         </template>
-                        <div v-if="availableLoras.length === 0" class="lora-list-hint">
+                        <div v-if="loraListLoaded && availableLoras.length === 0" class="lora-list-hint">
                             No LoRAs were returned by the server.
                         </div>
                         <div v-for="(row, index) in store.loraList" :key="index" class="lora-list-row">

--- a/src/views/OptionsView.vue
+++ b/src/views/OptionsView.vue
@@ -10,10 +10,12 @@ import {
     ElTabs,
     ElTabPane,
     ElMessage,
+    ElTooltip,
 } from 'element-plus';
 import {
     UploadFilled,
-    Download
+    Download,
+    Refresh
 } from '@element-plus/icons-vue';
 import { useOptionsStore } from '@/stores/options';
 import type { BasicColorSchema } from '@vueuse/core';
@@ -85,7 +87,13 @@ async function bulkDownload() {
             <el-tab-pane label="🖨️ Generation">
                 <h2>Generation Options</h2>
                 <el-form-item label="Base URL">
-                    <el-input class="apikey" prop="baseURL" v-model="store.baseURL" />
+                    <el-input class="apikey" prop="baseURL" v-model="store.baseURL">
+                        <template #append>
+                            <el-tooltip content="Invalidate all cached information for this server (LoRAs, samplers, schedulers, ...)" placement="top">
+                                <el-button :icon="Refresh" @click="generatorStore.invalidateApiCaches()" />
+                            </el-tooltip>
+                        </template>
+                    </el-input>
                 </el-form-item>
                 <h3>Parameter Controls</h3>
                 <div v-for="(item, key) in generatorStore.multiSelect" :key="key" >

--- a/test/expansions.test.ts
+++ b/test/expansions.test.ts
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parsePromptSegments, expandPromptSegments } from "../src/utils/expansions.ts";
+
+test("parsePromptSegments produces the segment list (X) for the sample", () => {
+    const segments = parsePromptSegments("ppp{111|222}qqq");
+    assert.deepEqual(
+        segments.map(s => s.type === "literal" ? { type: s.type, text: s.text } : { type: s.type, options: s.options }),
+        [
+            { type: "literal", text: "ppp" },
+            { type: "expansion", options: ["111", "222"] },
+            { type: "literal", text: "qqq" },
+        ],
+    );
+});
+
+test("segments tile the whole prompt with ordered offsets", () => {
+    const segments = parsePromptSegments("ppp{111|222}qqq");
+    assert.deepEqual(segments.map(s => [s.start, s.end]), [[0, 3], [3, 12], [12, 15]]);
+    assert.ok(segments.every((s, i) => i === 0 || segments[i - 1].end === s.start));
+    assert.equal(segments[segments.length - 1].end, 15);
+});
+
+test("expandPromptSegments expands the sample", () => {
+    assert.deepEqual(
+        expandPromptSegments(parsePromptSegments("ppp{111|222}qqq")),
+        ["ppp111qqq", "ppp222qqq"],
+    );
+});
+
+test("prompts without braces expand to themselves", () => {
+    assert.deepEqual(expandPromptSegments(parsePromptSegments("")), [""]);
+    assert.deepEqual(expandPromptSegments(parsePromptSegments("abc")), ["abc"]);
+});
+
+test("basic and multi-expansion results", () => {
+    const expand = (prompt: string) => expandPromptSegments(parsePromptSegments(prompt));
+    assert.deepEqual(expand("a{b|c}d"), ["abd", "acd"]);
+    assert.deepEqual(expand("{a|b}c{d|e}f"), ["acdf", "acef", "bcdf", "bcef"]);
+    assert.deepEqual(expand("{a|b|c}"), ["a", "b", "c"]);
+});
+
+test("repeated identical expansions expand both occurrences", () => {
+    const expand = (prompt: string) => expandPromptSegments(parsePromptSegments(prompt));
+    assert.deepEqual(expand("{a|b}x{a|b}"), ["axa", "axb", "bxa", "bxb"]);
+    assert.deepEqual(expand("{a|b}c{a|b}"), ["aca", "acb", "bca", "bcb"]);
+});
+
+test("edge-case expansions", () => {
+    const expand = (prompt: string) => expandPromptSegments(parsePromptSegments(prompt));
+    assert.deepEqual(expand("{}"), [""]);
+    assert.deepEqual(expand("{a|}b"), ["ab", "b"]);
+    assert.deepEqual(expand("{|a}b"), ["b", "ab"]);
+    assert.deepEqual(expand("{x}y"), ["xy"]);
+});
+
+test("an unclosed brace (and the rest of the prompt) is literal", () => {
+    assert.deepEqual(expandPromptSegments(parsePromptSegments("a{b|c")), ["a{b|c"]);
+});
+
+test("a stray closing brace is literal", () => {
+    assert.deepEqual(expandPromptSegments(parsePromptSegments("a}b")), ["a}b"]);
+});
+
+test("nested braces keep the historical (first-`}`-closes) semantics", () => {
+    const expand = (prompt: string) => expandPromptSegments(parsePromptSegments(prompt));
+    assert.deepEqual(expand("x{a|{b|c}}y"), ["xa}y", "x{b}y", "xc}y"]);
+    assert.deepEqual(expand("{a|b{c|d}}e{c|d}f"), ["a}ecf", "a}edf", "b{c}ecf", "b{c}edf", "d}ecf", "d}edf"]);
+});
+
+test("options containing String.replace patterns are used verbatim", () => {
+    const expand = (prompt: string) => expandPromptSegments(parsePromptSegments(prompt));
+    assert.deepEqual(expand("{a|$&|b}x"), ["ax", "$&x", "bx"]);
+    assert.deepEqual(expand("{hi|a$'b}!"), ["hi!", "a$'b!"]);
+});
+
+test("tags in literal segments map 1:1 onto the original prompt", () => {
+    const prompt = "a{l|m} <lora:x:0.5> {c|d} <lora:y:1>";
+    const segments = parsePromptSegments(prompt);
+    assert.deepEqual(segments.map(s => s.type), ["literal", "expansion", "literal", "expansion", "literal"]);
+
+    const tagPattern = /<lora:([^:>]+):([^>]+)>/g;
+    const found: { name: string; weight: string; origStart: number; origEnd: number }[] = [];
+    for (const segment of segments) {
+        if (segment.type !== "literal") continue;
+        for (const match of segment.text.matchAll(tagPattern)) {
+            found.push({
+                name: match[1],
+                weight: match[2],
+                origStart: segment.start + match.index,
+                origEnd: segment.start + match.index + match[0].length,
+            });
+        }
+    }
+    assert.deepEqual(found, [
+        { name: "x", weight: "0.5", origStart: 7, origEnd: 19 },
+        { name: "y", weight: "1", origStart: 26, origEnd: 36 },
+    ]);
+    for (const f of found) {
+        assert.ok(prompt.slice(f.origStart, f.origEnd).startsWith("<lora:"));
+    }
+});

--- a/test/loras.test.ts
+++ b/test/loras.test.ts
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { extractLorasFromPrompt } from "../src/utils/loras.ts";
+import { extractLorasFromPrompt, extractLoraRowsFromPrompt, allocateLoraRows } from "../src/utils/loras.ts";
+import { parsePromptSegments } from "../src/utils/expansions.ts";
+
+// extractLoraRowsFromPrompt takes the segments of parsePromptSegments(prompt)
+const extractRows = (prompt: string) => extractLoraRowsFromPrompt(prompt, parsePromptSegments(prompt));
 
 test("extracts tags and strips them from the prompt", () => {
     const [cleaned, data] = extractLorasFromPrompt("a <lora:x:0.5> b");
@@ -35,4 +39,136 @@ test("prompts without tags are returned unchanged", () => {
     const [cleaned, data] = extractLorasFromPrompt("just a prompt <with:colons> and stuff");
     assert.equal(cleaned, "just a prompt <with:colons> and stuff");
     assert.deepEqual(data, []);
+});
+
+test("extractLoraRowsFromPrompt converts a tag into a row and strips it from the prompt", () => {
+    const [cleaned, rows] = extractRows("a <lora:x:0.5> b");
+    assert.equal(cleaned, "a b");
+    assert.deepEqual(rows, [{ name: "x", multiplier: 0.5 }]);
+});
+
+test("extractLoraRowsFromPrompt leaves tags in expansion options as-is", () => {
+    const [cleaned, rows] = extractRows("{<lora:a:1>|<lora:b:2>} c <lora:c:0.3>");
+    assert.equal(cleaned, "{<lora:a:1>|<lora:b:2>} c");
+    assert.deepEqual(rows, [{ name: "c", multiplier: 0.3 }]);
+});
+
+test("extractLoraRowsFromPrompt leaves tags with an invalid weight as-is", () => {
+    const [cleaned1, rows1] = extractRows("a <lora:x:xyz> b");
+    assert.equal(cleaned1, "a <lora:x:xyz> b");
+    assert.deepEqual(rows1, []);
+
+    // an empty weight cannot match the tag syntax at all
+    const [cleaned2, rows2] = extractRows("a <lora:x:> b");
+    assert.equal(cleaned2, "a <lora:x:> b");
+    assert.deepEqual(rows2, []);
+});
+
+test("extractLoraRowsFromPrompt leaves high-noise tags as-is", () => {
+    const [cleaned, rows] = extractRows("a <lora:|high_noise|x:0.5> b <lora:y:0.2>");
+    assert.equal(cleaned, "a <lora:|high_noise|x:0.5> b");
+    assert.deepEqual(rows, [{ name: "y", multiplier: 0.2 }]);
+});
+
+test("extractLoraRowsFromPrompt leaves tags with an empty (whitespace) name as-is", () => {
+    const [cleaned, rows] = extractRows("a <lora:   :0.5> b");
+    assert.equal(cleaned, "a <lora:   :0.5> b");
+    assert.deepEqual(rows, []);
+});
+
+test("extractLoraRowsFromPrompt converts zero-weight tags", () => {
+    const [cleaned, rows] = extractRows("<lora:x:0>");
+    assert.equal(cleaned, "");
+    assert.deepEqual(rows, [{ name: "x", multiplier: 0 }]);
+});
+
+test("extractLoraRowsFromPrompt keeps duplicate tags as separate rows, in prompt order", () => {
+    const [cleaned, rows] = extractRows("<lora:b:0.3> <lora:a:0.7> <lora:b:0.4>");
+    assert.equal(cleaned, "");
+    assert.deepEqual(rows, [
+        { name: "b", multiplier: 0.3 },
+        { name: "a", multiplier: 0.7 },
+        { name: "b", multiplier: 0.4 },
+    ]);
+});
+
+test("extractLoraRowsFromPrompt never scans the part after a ' ### ' separator", () => {
+    const [cleaned, rows] = extractRows("a <lora:x:0.5> ### <lora:y:0.9> n");
+    assert.equal(cleaned, "a ### <lora:y:0.9> n");
+    assert.deepEqual(rows, [{ name: "x", multiplier: 0.5 }]);
+});
+
+test("extractLoraRowsFromPrompt returns the prompt unchanged when no tag is converted", () => {
+    const prompt = "  a  b <lora:x:oops> c  ";
+    const [cleaned, rows] = extractRows(prompt);
+    assert.equal(cleaned, prompt);
+    assert.deepEqual(rows, []);
+});
+
+test("allocateLoraRows overwrites the trailing empty rows first (oldest first)", () => {
+    const result = allocateLoraRows(
+        [
+            { lora: "a", multiplier: 0 },
+            { lora: "", multiplier: 0 },
+            { lora: "", multiplier: 1 },
+            { lora: "", multiplier: 0 },
+            { lora: "", multiplier: 0 },
+        ],
+        [
+            { lora: "x", multiplier: 0.5 },
+            { lora: "y", multiplier: 0.25 },
+            { lora: "z", multiplier: 0.75 },
+        ],
+    );
+    assert.deepEqual(result, [
+        { lora: "a", multiplier: 0 },
+        { lora: "", multiplier: 0 },
+        { lora: "", multiplier: 1 },
+        { lora: "x", multiplier: 0.5 },
+        { lora: "y", multiplier: 0.25 },
+        { lora: "z", multiplier: 0.75 },
+    ]);
+});
+
+test("allocateLoraRows appends new rows when there is no trailing empty space", () => {
+    const result = allocateLoraRows(
+        [{ lora: "a", multiplier: 1 }],
+        [{ lora: "x", multiplier: 0.5 }],
+    );
+    assert.deepEqual(result, [
+        { lora: "a", multiplier: 1 },
+        { lora: "x", multiplier: 0.5 },
+    ]);
+});
+
+test("allocateLoraRows does not reuse empty rows that are not trailing", () => {
+    const result = allocateLoraRows(
+        [{ lora: "", multiplier: 0 }, { lora: "a", multiplier: 1 }],
+        [{ lora: "x", multiplier: 0.5 }],
+    );
+    assert.deepEqual(result, [
+        { lora: "", multiplier: 0 },
+        { lora: "a", multiplier: 1 },
+        { lora: "x", multiplier: 0.5 },
+    ]);
+});
+
+test("allocateLoraRows uses only as many empty rows as there are incoming rows", () => {
+    const result = allocateLoraRows(
+        [{ lora: "a", multiplier: 1 }, { lora: "", multiplier: 0 }, { lora: "", multiplier: 0 }],
+        [{ lora: "x", multiplier: 0.5 }],
+    );
+    assert.deepEqual(result, [
+        { lora: "a", multiplier: 1 },
+        { lora: "x", multiplier: 0.5 },
+        { lora: "", multiplier: 0 },
+    ]);
+});
+
+test("allocateLoraRows returns a new array without mutating the input", () => {
+    const input = [{ lora: "", multiplier: 0 }];
+    const result = allocateLoraRows(input, [{ lora: "x", multiplier: 0.5 }]);
+    assert.notEqual(result, input);
+    assert.deepEqual(input, [{ lora: "", multiplier: 0 }]);
+    assert.deepEqual(result, [{ lora: "x", multiplier: 0.5 }]);
 });

--- a/test/loras.test.ts
+++ b/test/loras.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractLorasFromPrompt } from "../src/utils/loras.ts";
+
+test("extracts tags and strips them from the prompt", () => {
+    const [cleaned, data] = extractLorasFromPrompt("a <lora:x:0.5> b");
+    assert.equal(cleaned, "a  b");
+    assert.deepEqual(data, [{ name: "x", multiplier: 0.5 }]);
+});
+
+test("the |high_noise| prefix sets the flag and is stripped from the name", () => {
+    const [, data] = extractLorasFromPrompt("a <lora:|high_noise|x:0.5> b");
+    assert.deepEqual(data, [{ name: "x", multiplier: 0.5, is_high_noise: true }]);
+});
+
+test("duplicate tags are kept as separate entries", () => {
+    const [, data] = extractLorasFromPrompt("<lora:x:0.6> <lora:x:0.3>");
+    assert.deepEqual(data, [
+        { name: "x", multiplier: 0.6 },
+        { name: "x", multiplier: 0.3 },
+    ]);
+});
+
+test("tags with a non-numeric or blank multiplier are stripped but not recorded", () => {
+    const [cleaned1, data1] = extractLorasFromPrompt("a <lora:x:xyz> b");
+    assert.equal(cleaned1, "a  b");
+    assert.deepEqual(data1, []);
+
+    const [cleaned2, data2] = extractLorasFromPrompt("a <lora:x:   > b");
+    assert.equal(cleaned2, "a  b");
+    assert.deepEqual(data2, []);
+});
+
+test("prompts without tags are returned unchanged", () => {
+    const [cleaned, data] = extractLorasFromPrompt("just a prompt <with:colons> and stuff");
+    assert.equal(cleaned, "just a prompt <with:colons> and stuff");
+    assert.deepEqual(data, []);
+});


### PR DESCRIPTION
Vibe-coded with Qwen3.8-27B-UD-Q3_K_XL in 3 turns 😶

<img width="590" height="654" alt="lora2" src="https://github.com/user-attachments/assets/bd4e57c6-23c6-40fe-b979-d63757c9424b" />

<img width="699" height="345" alt="lora3" src="https://github.com/user-attachments/assets/5730f803-4121-466a-b171-68e7b8a45c0e" />

If you think that's desirable, I'll refine it:
* The top-level Enable / Disable is likely unneeded?
* Persistent or non-persistent?
* Separate UI section (maybe a foldable panel)?
* Per-LoRA sliders like this, or a single universal control like sd.cpp? :
<img width="430" height="134" alt="image" src="https://github.com/user-attachments/assets/c9640052-852d-436d-8691-a80a9fd37bea" />
